### PR TITLE
Add support for specifying cookie domain with JWT_COOKIE_DOMAIN

### DIFF
--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -67,7 +67,7 @@ class _Config(object):
 
     @property
     def cookie_domain(self):
-        return current_app.config.get('JWT_COOKIE_DOMAIN', None)
+        return current_app.config['JWT_COOKIE_DOMAIN']
 
     @property
     def session_cookie(self):

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -10,7 +10,7 @@ class _Config(object):
     Helper object for accessing and verifying options in this extension. This
     is meant for internal use of the application; modifying config options
     should be done with flasks ```app.config```.
-    
+
     Default values for the configuration options are set in the jwt_manager
     object. All of these values are read only.
     """
@@ -64,6 +64,10 @@ class _Config(object):
     @property
     def cookie_secure(self):
         return current_app.config['JWT_COOKIE_SECURE']
+
+    @property
+    def cookie_domain(self):
+        return current_app.config.get('JWT_COOKIE_DOMAIN', None)
 
     @property
     def session_cookie(self):

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -119,6 +119,7 @@ class JWTManager(object):
         app.config.setdefault('JWT_ACCESS_COOKIE_PATH', '/')
         app.config.setdefault('JWT_REFRESH_COOKIE_PATH', '/')
         app.config.setdefault('JWT_COOKIE_SECURE', False)
+        app.config.setdefault('JWT_COOKIE_DOMAIN', None)
         app.config.setdefault('JWT_SESSION_COOKIE', True)
 
         # Options for using double submit csrf protection

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -70,6 +70,7 @@ def set_access_cookies(response, encoded_access_token):
                         max_age=config.cookie_max_age,
                         secure=config.cookie_secure,
                         httponly=True,
+                        domain=config.cookie_domain,
                         path=config.access_cookie_path)
 
     # If enabled, set the csrf double submit access cookie
@@ -79,6 +80,7 @@ def set_access_cookies(response, encoded_access_token):
                             max_age=config.cookie_max_age,
                             secure=config.cookie_secure,
                             httponly=False,
+                            domain=config.cookie_domain,
                             path=config.access_csrf_cookie_path)
 
 
@@ -97,6 +99,7 @@ def set_refresh_cookies(response, encoded_refresh_token):
                         max_age=config.cookie_max_age,
                         secure=config.cookie_secure,
                         httponly=True,
+                        domain=config.cookie_domain,
                         path=config.refresh_cookie_path)
 
     # If enabled, set the csrf double submit refresh cookie
@@ -106,6 +109,7 @@ def set_refresh_cookies(response, encoded_refresh_token):
                             max_age=config.cookie_max_age,
                             secure=config.cookie_secure,
                             httponly=False,
+                            domain=config.cookie_domain,
                             path=config.refresh_csrf_cookie_path)
 
 
@@ -124,12 +128,14 @@ def unset_jwt_cookies(response):
                         expires=0,
                         secure=config.cookie_secure,
                         httponly=True,
+                        domain=config.cookie_domain,
                         path=config.refresh_cookie_path)
     response.set_cookie(config.access_cookie_name,
                         value='',
                         expires=0,
                         secure=config.cookie_secure,
                         httponly=True,
+                        domain=config.cookie_domain,
                         path=config.access_cookie_path)
 
     if config.csrf_protect and config.csrf_in_cookies:
@@ -138,10 +144,12 @@ def unset_jwt_cookies(response):
                             expires=0,
                             secure=config.cookie_secure,
                             httponly=False,
+                            domain=config.cookie_domain,
                             path=config.refresh_csrf_cookie_path)
         response.set_cookie(config.access_csrf_cookie_name,
                             value='',
                             expires=0,
                             secure=config.cookie_secure,
                             httponly=False,
+                            domain=config.cookie_domain,
                             path=config.access_csrf_cookie_path)


### PR DESCRIPTION
I need to be able to specify the cookie domain so that I can access the cookies on subdomains; this PR implements an optional `JWT_COOKIE_DOMAIN` config variable which will let that be set.