### PR TITLE
add @jwt_optional view decorator and corresponding unit tests

### DIFF
--- a/flask_jwt_extended/__init__.py
+++ b/flask_jwt_extended/__init__.py
@@ -1,6 +1,7 @@
 from .jwt_manager import JWTManager
 from .view_decorators import (
-    jwt_required, fresh_jwt_required, jwt_refresh_token_required
+    jwt_required, fresh_jwt_required, jwt_refresh_token_required,
+    jwt_optional
 )
 from .utils import (
     create_refresh_token, create_access_token, get_jwt_identity,


### PR DESCRIPTION
Here's the jwt_optional decorator we discussed on IRC earlier today. I ended up copying most/all of the test cases for failed authorization with @jwt_required and rewriting them for the new decorator. I'm happy to make revisions or change formatting, of course.