### PR TITLE
Getting Token From Encoded Token

### DIFF
--- a/flask_jwt_extended/blacklist.py
+++ b/flask_jwt_extended/blacklist.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 from flask_jwt_extended.config import config
 from flask_jwt_extended.exceptions import RevokedTokenError
+from flask_jwt_extended.utils import get_jti
 
 # TODO make simplekv an optional dependency if blacklist is disabled
 
@@ -80,13 +81,24 @@ def unrevoke_token(jti):
     """
     Revoke a token
 
-    :param jti: The jti of the token to revoke
+    :param jti: The jti of the token to unrevoke
     """
     _update_token(jti, revoked=False)
 
 
 @_verify_blacklist_enabled
-def get_stored_token(jti):
+def get_stored_token(jti=None, encoded_token=None):
+    """
+    Get the stored token for the passed in jti or encoded_token
+
+    :param jti: The jti of the token
+    :param encoded_token: The encoded JWT string
+    :return: Python dictionary with the token information
+    """
+    if jti is None and encoded_token is not None:
+        jti = get_jti(encoded_token)
+    elif jti is None and encoded_token is None:
+        raise ValueError('Either jti or encoded_token is required')
     return _get_token_from_store(jti)
 
 

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -32,6 +32,16 @@ def get_jwt_claims():
     return get_raw_jwt().get('user_claims', {})
 
 
+def get_jti(encoded_token):
+    """
+    Returns the JTI given the JWT encoded token
+
+    :param encoded_token: The encoded JWT string
+    :return: The JTI of the token
+    """
+    return decode_jwt(encoded_token, config.secret_key, config.algorithm, config.csrf_protect).get('jti')
+
+
 def _get_jwt_manager():
     try:
         return current_app.jwt_manager


### PR DESCRIPTION
- Implemented `get_jti` that takes the encoded token and returns the token dictionary
- Added `encoded_token` as a kwarg for `get_stored_token`, so users can retrieve token dictionary given the `encoded_token`