### PR TITLE
Ignoring OPTIONS method in jwt_required (fix #119)

### DIFF
--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -238,6 +238,6 @@ class _Config(object):
 
     @property
     def exempt_methods(self):
-        return set(["OPTIONS"])
+        return {"OPTIONS"}
 
 config = _Config()

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -236,6 +236,8 @@ class _Config(object):
     def user_claims_key(self):
         return current_app.config['JWT_USER_CLAIMS']
 
+    @property
+    def exempt_methods(self):
+        return set(["OPTIONS"])
+
 config = _Config()
-
-

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -32,12 +32,13 @@ def jwt_required(fn):
     """
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        jwt_data = _decode_jwt_from_request(request_type='access')
-        ctx_stack.top.jwt = jwt_data
-        if not verify_token_claims(jwt_data[config.user_claims_key]):
-            raise UserClaimsVerificationError('User claims verification failed')
-        _load_user(jwt_data[config.identity_claim_key])
-        return fn(*args, **kwargs)
+        if request.method not in config.exempt_methods:
+            jwt_data = _decode_jwt_from_request(request_type='access')
+            ctx_stack.top.jwt = jwt_data
+            if not verify_token_claims(jwt_data[config.user_claims_key]):
+                raise UserClaimsVerificationError('User claims verification failed')
+            _load_user(jwt_data[config.identity_claim_key])
+            return fn(*args, **kwargs)
     return wrapper
 
 

--- a/tests/test_options_method.py
+++ b/tests/test_options_method.py
@@ -25,7 +25,6 @@ def app():
     app.register_blueprint(protected_bp)
     return app
 
-
 def test_access_protected_enpoint(app):
     client = app.test_client()
     assert client.get('/protected').status_code == 401 # ok

--- a/tests/test_options_method.py
+++ b/tests/test_options_method.py
@@ -30,22 +30,16 @@ def app():
     return app
 
 def test_access_jwt_required_enpoint(app):
-    # Test the options method shoud not be
-    # affected by jwt required
     res = app.test_client().options('/jwt_required')
     assert res.status_code == 200
     assert res.data == b'ok'
 
 def test_access_jwt_refresh_token_required_enpoint(app):
-    # Test the options method shoud not be
-    # affected by jwt required
     res = app.test_client().options('/jwt_refresh_token_required')
     assert res.status_code == 200
     assert res.data == b'ok'
 
 def test_access_fresh_jwt_required_enpoint(app):
-    # Test the options method shoud not be
-    # affected by jwt required
     res = app.test_client().options('/fresh_jwt_required')
     assert res.status_code == 200
     assert res.data == b'ok'

--- a/tests/test_options_method.py
+++ b/tests/test_options_method.py
@@ -1,0 +1,35 @@
+from flask import Flask, Blueprint
+from flask_jwt_extended import JWTManager, jwt_required, create_access_token
+import pytest
+
+@pytest.fixture(scope='function')
+def app():
+    app = Flask(__name__)
+    app.config['JWT_SECRET_KEY'] = 'secret'
+    JWTManager(app)
+
+    protected_bp = Blueprint('protected', __name__)
+
+    # This protects the entire blueprint,
+    # Also the OPTIONS method
+    @protected_bp.before_request
+    @jwt_required
+    def protect():
+        pass
+
+    @protected_bp.route('/protected', methods=["GET"])
+    @jwt_required
+    def protected():
+        return 'ok'
+
+    app.register_blueprint(protected_bp)
+    return app
+
+
+def test_access_protected_enpoint(app):
+    client = app.test_client()
+    assert client.get('/protected').status_code == 401 # ok
+
+def test_access_protected_enpoint_options(app):
+    client = app.test_client()
+    assert client.options('/protected').status_code == 200 # test fails


### PR DESCRIPTION
This shoud fix #119!

All test passes!

```
$ python -m pytest
=================================================== test session starts ===================================================
platform darwin -- Python 3.6.1, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /Users/ludus/develop/playground/flask-jwt-extended, inifile:
collected 91 items

tests/test_asymmetric_crypto.py .                                                                                   [  1%]
tests/test_blacklist.py ...........                                                                                 [ 13%]
tests/test_claims_verification.py ............                                                                      [ 26%]
tests/test_config.py ..........                                                                                     [ 37%]
tests/test_cookies.py ..................                                                                            [ 57%]
tests/test_decode_tokens.py ............                                                                            [ 70%]
tests/test_headers.py ...                                                                                           [ 73%]
tests/test_headers_and_cookies.py ...                                                                               [ 76%]
tests/test_options_method.py ..                                                                                     [ 79%]
tests/test_user_claims_loader.py ....                                                                               [ 83%]
tests/test_user_loader.py ......                                                                                    [ 90%]
tests/test_view_decorators.py .........                                                                             [100%]

```