### PR TITLE
Fixed docs oversight regarding logout route access

### DIFF
--- a/examples/csrf_protection_with_cookies.py
+++ b/examples/csrf_protection_with_cookies.py
@@ -82,7 +82,6 @@ def refresh():
 # in order to logout. unset_jwt_cookies is a helper function to
 # do just that.
 @app.route('/token/remove', methods=['POST'])
-@jwt_required
 def logout():
     resp = jsonify({'logout': True})
     unset_jwt_cookies(resp)

--- a/examples/jwt_in_cookie.py
+++ b/examples/jwt_in_cookie.py
@@ -80,7 +80,6 @@ def refresh():
 # in order to logout. unset_jwt_cookies is a helper function to
 # do just that.
 @app.route('/token/remove', methods=['POST'])
-@jwt_required
 def logout():
     resp = jsonify({'logout': True})
     unset_jwt_cookies(resp)


### PR DESCRIPTION
If a user's access token has expired this decorator prevents him from
logging out and removing his refresh token cookie.  This removes that
limitation.  Closes #134.