### PR TITLE
[#138] actually pass to jwt.encode

### DIFF
--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -27,7 +27,8 @@ def _encode_jwt(additional_token_data, expires_delta, secret, algorithm,
     if expires_delta:
         token_data['exp'] = now + expires_delta
     token_data.update(additional_token_data)
-    encoded_token = jwt.encode(token_data, secret, algorithm).decode('utf-8')
+    encoded_token = jwt.encode(token_data, secret, algorithm,
+                               json_encoder=json_encoder).decode('utf-8')
     return encoded_token
 
 


### PR DESCRIPTION
Sorry for the transcription error, but I missed this one line (which was the whole point ... 🤦‍♂️ ).

Tests still pass.

Signed-off-by: Matthew Story <matt@directorof.me>