### PR TITLE
`@decode_key_loader` callback added for dynamic decode keys

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,7 @@ Configuring Flask-JWT-Extended
   .. automethod:: user_loader_callback_loader
   .. automethod:: user_loader_error_loader
   .. automethod:: unauthorized_loader
+  .. automethod:: decode_key_loader
 
 
 Protected endpoint decorators

--- a/docs/changing_default_behavior.rst
+++ b/docs/changing_default_behavior.rst
@@ -43,6 +43,8 @@ and what the return values of your callback functions need to be.
       - Function that is called to verify the user_claims data. Must return True or False
     * - :meth:`~flask_jwt_extended.JWTManager.claims_verification_failed_loader`
       - Function that is called when the user claims verification callback returns False
+    * - :meth:`~flask_jwt_extended.JWTManager.decode_key_loader`
+      - Function that is called to load the decode/secret key before verifying a token
 
 Dynamic token expires time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/flask_jwt_extended/default_callbacks.py
+++ b/flask_jwt_extended/default_callbacks.py
@@ -101,3 +101,7 @@ def default_verify_claims_failed_callback():
     error message with a 400 status code
     """
     return jsonify({config.error_msg_key: 'User claims verification failed'}), 400
+
+
+def default_decode_key_callback(claims):
+    return config.decode_key

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -13,7 +13,8 @@ from flask_jwt_extended.default_callbacks import (
     default_user_identity_callback, default_invalid_token_callback,
     default_unauthorized_callback, default_needs_fresh_token_callback,
     default_revoked_token_callback, default_user_loader_error_callback,
-    default_claims_verification_callback, default_verify_claims_failed_callback
+    default_claims_verification_callback, default_verify_claims_failed_callback,
+    default_decode_key_callback
 )
 from flask_jwt_extended.tokens import (
     encode_refresh_token, encode_access_token
@@ -53,6 +54,7 @@ class JWTManager(object):
         self._token_in_blacklist_callback = None
         self._claims_verification_callback = default_claims_verification_callback
         self._verify_claims_failed_callback = default_verify_claims_failed_callback
+        self._decode_key_callback = default_decode_key_callback
 
         # Register this extension with the flask app now (if it is provided)
         if app is not None:
@@ -376,6 +378,21 @@ class JWTManager(object):
         a *Flask response*.
         """
         self._verify_claims_failed_callback = callback
+        return callback
+
+    def decode_key_loader(self, callback):
+        """
+        This decorator sets the callback function for getting the JWT decode key and
+        can be used to dynamically choose the appropriate decode key based on token
+        contents.
+        The default implementation returns the decode key from config (either
+        `JWT_SECRET_KEY` or `JWT_PUBLIC_KEY` depending on signing algorithm).
+
+        *HINT*: The callback function must be a function that takes only **one** argument,
+        which is a dictionary of the claims encoded in the JWT and must return a *string*
+        which is the decode key to verify the token.
+        """
+        self._decode_key_callback = callback
         return callback
 
     def _create_refresh_token(self, identity, expires_delta=None):

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -11,6 +11,7 @@ from flask_jwt_extended.exceptions import (
     RevokedTokenError, UserClaimsVerificationError, WrongTokenError
 )
 from flask_jwt_extended.tokens import decode_jwt
+import jwt
 
 
 # Proxy to access the current user
@@ -71,9 +72,14 @@ def decode_token(encoded_token, csrf_value=None):
     :param encoded_token: The encoded JWT to decode into a python dict.
     :param csrf_value: Expected CSRF double submit value (optional)
     """
+    jwt_manager = _get_jwt_manager()
+    unverified_claims = jwt.decode(
+        encoded_token, verify=False, algorithms=config.algorithm
+    )
+    secret = jwt_manager._decode_key_callback(unverified_claims)
     return decode_jwt(
         encoded_token=encoded_token,
-        secret=config.decode_key,
+        secret=secret,
         algorithm=config.algorithm,
         identity_claim_key=config.identity_claim_key,
         user_claims_key=config.user_claims_key,


### PR DESCRIPTION
This implementes a `@decode_key_loader` callback decorator to override `config.decode_key`

```python
@jwt_manager.decode_key_loader
def get_decode_key(claims):
    if claims['something'] == 'a':
        return key_for_a
    ....
```