### PR TITLE
Add tox.ini and tests in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include README.md LICENSE requirements.txt
+include LICENSE README.md requirements.txt tox.ini
+recursive-include tests *.py


### PR DESCRIPTION
I have added the `tests` directory and the `tox.ini` in `MANIFEST.in` to be able to run the tests after installing the source via PyPi to check if the installation ran successfully.

Motivation analogous to https://github.com/NixOS/nixpkgs/pull/45871#issuecomment-417854526 because I want to add this package to nixpkgs.