### PR TITLE
Implement the ability to define a leeway when validating JWT tokens.

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -47,6 +47,11 @@ General Options:
 ``JWT_DECODE_AUDIENCE``           The audience you expect in a JWT when decoding it.
                                   If this option differs from the 'aud' claim in a JWT, the ``'invalid_token_callback'`` is invoked.
                                   Defaults to ``'None'``.
+``JWT_DECODE_LEEWAY``             Define the leeway part of the expiration time definition, which
+                                  means you can validate an expiration time which is in the past but
+                                  not very far. This leeway is used for `nbf` (“not before”) and `exp`
+                                  (“expiration time”).
+                                  Defaults to ``0``
 ================================= =========================================
 
 

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -292,5 +292,9 @@ class _Config(object):
     def audience(self):
         return current_app.config['JWT_DECODE_AUDIENCE']
 
+    @property
+    def leeway(self):
+        return current_app.config['JWT_DECODE_LEEWAY']
+
 
 config = _Config()

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -197,6 +197,7 @@ class JWTManager(object):
         app.config.setdefault('JWT_IDENTITY_CLAIM', 'identity')
         app.config.setdefault('JWT_USER_CLAIMS', 'user_claims')
         app.config.setdefault('JWT_DECODE_AUDIENCE', None)
+        app.config.setdefault('JWT_DECODE_LEEWAY', 0)
 
         app.config.setdefault('JWT_CLAIMS_IN_REFRESH_TOKEN', False)
 

--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -113,7 +113,8 @@ def encode_refresh_token(identity, secret, algorithm, expires_delta, user_claims
 
 
 def decode_jwt(encoded_token, secret, algorithm, identity_claim_key,
-               user_claims_key, csrf_value=None, audience=None):
+               user_claims_key, csrf_value=None, audience=None,
+               leeway=0):
     """
     Decodes an encoded JWT
 
@@ -124,10 +125,13 @@ def decode_jwt(encoded_token, secret, algorithm, identity_claim_key,
     :param user_claims_key: expected key that contains the user claims
     :param csrf_value: Expected double submit csrf value
     :param audience: expected audience in the JWT
+    :param leeway: optional leeway to add some margin around expiration times
     :return: Dictionary containing contents of the JWT
     """
+
     # This call verifies the ext, iat, nbf, and aud claims
-    data = jwt.decode(encoded_token, secret, algorithms=[algorithm], audience=audience)
+    data = jwt.decode(encoded_token, secret, algorithms=[algorithm], audience=audience,
+                      leeway=leeway)
 
     # Make sure that any custom claims we expect in the token are present
     if 'jti' not in data:

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -84,8 +84,9 @@ def decode_token(encoded_token, csrf_value=None):
         secret = jwt_manager._decode_key_callback(unverified_claims, unverified_headers)
     except TypeError:
         msg = (
-                "The single-argument (unverified_claims) form of decode_key_callback is deprecated. "
-                "Update your code to use the two-argument form (unverified_claims, unverified_headers)."
+            "The single-argument (unverified_claims) form of decode_key_callback ",
+            "is deprecated. Update your code to use the two-argument form ",
+            "(unverified_claims, unverified_headers)."
         )
         warn(msg, DeprecationWarning)
         secret = jwt_manager._decode_key_callback(unverified_claims)
@@ -96,7 +97,8 @@ def decode_token(encoded_token, csrf_value=None):
         identity_claim_key=config.identity_claim_key,
         user_claims_key=config.user_claims_key,
         csrf_value=csrf_value,
-        audience=config.audience
+        audience=config.audience,
+        leeway=config.leeway
     )
 
 


### PR DESCRIPTION
PyJWT library implement a way to define a “leeway” for time
validations.

> PyJWT also supports the leeway part of the expiration time
> definition, which means you can validate a expiration time which is
> in the past but not very far. For example, if you have a JWT payload
> with a expiration time set to 30 seconds after creation but you know
> that sometimes you will process it after 30 seconds, you can set a
> leeway of 10 seconds in order to have some margin:
>
> https://github.com/jpadilla/pyjwt/blob/master/docs/usage.rst

This is implemented as an optional configuration setting,
`JWT_DECODE_LEEWAY`.