### PR TITLE
Added possibility to disable audience verification

### DIFF
--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -1,6 +1,5 @@
 import datetime
 import uuid
-
 from calendar import timegm
 
 import jwt
@@ -114,7 +113,7 @@ def encode_refresh_token(identity, secret, algorithm, expires_delta, user_claims
 
 def decode_jwt(encoded_token, secret, algorithm, identity_claim_key,
                user_claims_key, csrf_value=None, audience=None,
-               leeway=0, allow_expired=False):
+               leeway=0, allow_expired=False, verify_audience=False):
     """
     Decodes an encoded JWT
 
@@ -127,11 +126,14 @@ def decode_jwt(encoded_token, secret, algorithm, identity_claim_key,
     :param audience: expected audience in the JWT
     :param leeway: optional leeway to add some margin around expiration times
     :param allow_expired: Options to ignore exp claim validation in token
+    :param verify_audience: Options to ignore aud claim validation in token
     :return: Dictionary containing contents of the JWT
     """
     options = {}
     if allow_expired:
         options['verify_exp'] = False
+
+    options['verify_aud'] = verify_audience
 
     # This call verifies the ext, iat, nbf, and aud claims
     data = jwt.decode(encoded_token, secret, algorithms=[algorithm], audience=audience,

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -1,6 +1,7 @@
+from warnings import warn
+
 from flask import current_app
 from werkzeug.local import LocalProxy
-from warnings import warn
 
 try:
     from flask import _app_ctx_stack as ctx_stack
@@ -82,6 +83,12 @@ def decode_token(encoded_token, csrf_value=None, allow_expired=False):
     unverified_headers = jwt.get_unverified_header(encoded_token)
     # Attempt to call callback with both claims and headers, but fallback to just claims
     # for backwards compatibility
+
+    # Added possibility to disable audience check
+    verify_audience = True
+    if config.audience is None:
+        verify_audience = False
+
     try:
         secret = jwt_manager._decode_key_callback(unverified_claims, unverified_headers)
     except TypeError:
@@ -102,7 +109,8 @@ def decode_token(encoded_token, csrf_value=None, allow_expired=False):
         csrf_value=csrf_value,
         audience=config.audience,
         leeway=config.leeway,
-        allow_expired=allow_expired
+        allow_expired=allow_expired,
+        verify_audience=verify_audience
     )
 
 


### PR DESCRIPTION
# Added possibility to disable audience check

We have projects where the configured audience via "keycloak" is not necessary.
In the actual jwt-extended code we had no chance to disable the audience check.

Of course you can use the *JWT_DECODE_AUDIENCE* setting, but in our case the token we receive have always other audiences.

In this PR it is possible to disable audience check when no audience is configured:

`
JWT_DECODE_AUDIENCE=NONE
`

