### PR TITLE
relax config type check on JWT_*_TOKEN_EXPIRES

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -20,10 +20,14 @@ General Options:
                                   in a sequence or a set to check more then one location, such as:
                                   ``('headers', 'cookies')``. Defaults to ``['headers']``
 ``JWT_ACCESS_TOKEN_EXPIRES``      How long an access token should live before it expires. This
-                                  takes a ``datetime.timedelta`` or an ``int`` (seconds), and defaults to 15 minutes.
+                                  takes any value that can be safely added to a ``datetime.datetime`` object, including
+                                  ``datetime.timedelta``, `dateutil.relativedelta <https://dateutil.readthedocs.io/en/stable/relativedelta.html>`_,
+                                  or an ``int`` (seconds), and defaults to 15 minutes.
                                   Can be set to ``False`` to disable expiration.
 ``JWT_REFRESH_TOKEN_EXPIRES``     How long a refresh token should live before it expires. This
-                                  takes a ``datetime.timedelta`` or ``int`` (seconds), and defaults to 30 days.
+                                  takes any value that can be safely added to a ``datetime.datetime`` object, including
+                                  ``datetime.timedelta``, `dateutil.relativedelta <https://dateutil.readthedocs.io/en/stable/relativedelta.html>`_,
+                                  or an ``int`` (seconds), and defaults to 30 days.
                                   Can be set to ``False`` to disable expiration.
 ``JWT_ALGORITHM``                 Which algorithm to sign the JWT with. `See here <https://pyjwt.readthedocs.io/en/latest/algorithms.html>`_
                                   for the options. Defaults to ``'HS256'``.

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -1,5 +1,6 @@
 import datetime
 from warnings import warn
+from six import raise_from
 
 # In Python 2.7 collections.abc is a part of the collections module.
 try:
@@ -188,10 +189,14 @@ class _Config(object):
         delta = current_app.config['JWT_ACCESS_TOKEN_EXPIRES']
         if type(delta) is int:
             delta = datetime.timedelta(seconds=delta)
-        if not isinstance(delta, datetime.timedelta) and delta is not False:
-            err = 'JWT_ACCESS_TOKEN_EXPIRES must be a ' \
-                  'datetime.timedelta, int or False'
-            raise RuntimeError(err)
+        if delta is not False:
+            try:
+                delta + datetime.datetime.now()
+            except TypeError as e:
+                err = (
+                    "must be able to add JWT_ACCESS_TOKEN_EXPIRES to datetime.datetime"
+                )
+                raise_from(RuntimeError(err), e)
         return delta
 
     @property
@@ -199,10 +204,14 @@ class _Config(object):
         delta = current_app.config['JWT_REFRESH_TOKEN_EXPIRES']
         if type(delta) is int:
             delta = datetime.timedelta(seconds=delta)
-        if not isinstance(delta, datetime.timedelta) and delta is not False:
-            err = 'JWT_REFRESH_TOKEN_EXPIRES must be a ' \
-                  'datetime.timedelta, int or False'
-            raise RuntimeError(err)
+        if delta is not False:
+            try:
+                delta + datetime.datetime.now()
+            except TypeError as e:
+                err = (
+                    "must be able to add JWT_REFRESH_TOKEN_EXPIRES to datetime.datetime"
+                )
+                raise_from(RuntimeError(err), e)
         return delta
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(name='Flask-JWT-Extended',
           'Werkzeug>=0.14',  # Needed for SameSite cookie functionality
           'Flask',
           'PyJWT',
+          'six',
       ],
       extras_require={
         'asymmetric_crypto':  ["cryptography >= 2.3"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import warnings
 
 import pytest
 from datetime import timedelta
+from dateutil.relativedelta import relativedelta
 from flask import Flask
 from flask.json import JSONEncoder
 
@@ -72,7 +73,8 @@ def test_default_configs(app):
         assert config.error_msg_key == 'msg'
 
 
-def test_override_configs(app):
+@pytest.mark.parametrize("delta_func", [timedelta, relativedelta])
+def test_override_configs(app, delta_func):
     app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'query_string', 'json']
     app.config['JWT_HEADER_NAME'] = 'TestHeader'
     app.config['JWT_HEADER_TYPE'] = 'TestType'
@@ -100,8 +102,8 @@ def test_override_configs(app):
     app.config['JWT_ACCESS_CSRF_HEADER_NAME'] = 'X-ACCESS-CSRF'
     app.config['JWT_REFRESH_CSRF_HEADER_NAME'] = 'X-REFRESH-CSRF'
 
-    app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(minutes=5)
-    app.config['JWT_REFRESH_TOKEN_EXPIRES'] = timedelta(days=5)
+    app.config['JWT_ACCESS_TOKEN_EXPIRES'] = delta_func(minutes=5)
+    app.config['JWT_REFRESH_TOKEN_EXPIRES'] = delta_func(days=5)
     app.config['JWT_ALGORITHM'] = 'HS512'
 
     app.config['JWT_BLACKLIST_ENABLED'] = True
@@ -151,8 +153,8 @@ def test_override_configs(app):
         assert config.access_csrf_header_name == 'X-ACCESS-CSRF'
         assert config.refresh_csrf_header_name == 'X-REFRESH-CSRF'
 
-        assert config.access_expires == timedelta(minutes=5)
-        assert config.refresh_expires == timedelta(days=5)
+        assert config.access_expires == delta_func(minutes=5)
+        assert config.refresh_expires == delta_func(days=5)
         assert config.algorithm == 'HS512'
 
         assert config.blacklist_enabled is True

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -1,6 +1,7 @@
 import jwt
 import pytest
 from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 import warnings
 
 from flask import Flask
@@ -103,9 +104,10 @@ def test_bad_token_type(app, default_access_token):
             decode_token(bad_type_token)
 
 
-def test_expired_token(app):
+@pytest.mark.parametrize("delta_func", [timedelta, relativedelta])
+def test_expired_token(app, delta_func):
     with app.test_request_context():
-        delta = timedelta(minutes=-5)
+        delta = delta_func(minutes=-5)
         access_token = create_access_token('username', expires_delta=delta)
         refresh_token = create_refresh_token('username', expires_delta=delta)
         with pytest.raises(ExpiredSignatureError):
@@ -114,9 +116,10 @@ def test_expired_token(app):
             decode_token(refresh_token)
 
 
-def test_allow_expired_token(app):
+@pytest.mark.parametrize("delta_func", [timedelta, relativedelta])
+def test_allow_expired_token(app, delta_func):
     with app.test_request_context():
-        delta = timedelta(minutes=-5)
+        delta = delta_func(minutes=-5)
         access_token = create_access_token('username', expires_delta=delta)
         refresh_token = create_refresh_token('username', expires_delta=delta)
         for token in (access_token, refresh_token):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
   pytest
   coverage
   cryptography
+  python-dateutil
 # TODO why does this not work?
 # extras =
 #  asymmetric_crypto


### PR DESCRIPTION
Instead of requiring JWT_ACCESS_TOKEN_EXPIRES and JWT_REFRESH_TOKEN_EXPIRES to
be of type `datetime.timedelta` or `False`, checks in config.py support any
value that can be successfully added to a `datetime.datetime` object.

Closes #214.

(I'm not well-configured to test this atm, so I'm relying on CI to slap me down if there's a problem here.)