### PR TITLE
fix current_roles contains a dict instead of the list of roles

### DIFF
--- a/examples/tokens_from_complex_objects.py
+++ b/examples/tokens_from_complex_objects.py
@@ -62,7 +62,7 @@ def login():
 def protected():
     ret = {
         'current_identity': get_jwt_identity(),  # test
-        'current_roles': get_jwt_claims()  # ['foo', 'bar']
+        'current_roles': get_jwt_claims()['roles']  # ['foo', 'bar']
     }
     return jsonify(ret), 200
 


### PR DESCRIPTION
According to  `add_claims_to_access_token(...)`

https://github.com/vimalloc/flask-jwt-extended/blob/ab0e314cddfc6fdf28a46318fa03c5563aa4b46f/examples/tokens_from_complex_objects.py#L26-L28

the result of `get_jwt_claims()` will be `{'roles': [...]}`, so taking the `['roles']` will provide the list of roles mentioned in the comments

https://github.com/vimalloc/flask-jwt-extended/blob/ab0e314cddfc6fdf28a46318fa03c5563aa4b46f/examples/tokens_from_complex_objects.py#L65