### PR TITLE
Use the order of values in JWT_TOKEN_LOCATION to set order of precedence

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -18,7 +18,9 @@ General Options:
 ``JWT_TOKEN_LOCATION``            Where to look for a JWT when processing a request. The
                                   options are ``'headers'``, ``'cookies'``, ``'query_string'``, or ``'json'``. You can pass
                                   in a sequence or a set to check more then one location, such as:
-                                  ``('headers', 'cookies')``. Defaults to ``['headers']``
+                                  ``('headers', 'cookies')``. Defaults to ``['headers']``.
+                                  The order sets the precedence, so that if a valid token is
+                                  found in an earlier location in this list, the request is authenticated.
 ``JWT_ACCESS_TOKEN_EXPIRES``      How long an access token should live before it expires. This
                                   takes any value that can be safely added to a ``datetime.datetime`` object, including
                                   ``datetime.timedelta``, `dateutil.relativedelta <https://dateutil.readthedocs.io/en/stable/relativedelta.html>`_,

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -253,13 +253,15 @@ def _decode_jwt_from_request(request_type):
     # add the functions in the order specified in JWT_TOKEN_LOCATION
     for location in locations:
         if location == 'cookies' and config.jwt_in_cookies:
-            get_encoded_token_functions.append(lambda: _decode_jwt_from_cookies(request_type))
+            get_encoded_token_functions.append(
+                lambda: _decode_jwt_from_cookies(request_type))
         if location == 'query_string' and config.jwt_in_query_string:
             get_encoded_token_functions.append(_decode_jwt_from_query_string)
         if location == 'headers' and config.jwt_in_headers:
             get_encoded_token_functions.append(_decode_jwt_from_headers)
         if location == 'json' and config.jwt_in_json:
-            get_encoded_token_functions.append(lambda: _decode_jwt_from_json(request_type))
+            get_encoded_token_functions.append(
+                lambda: _decode_jwt_from_json(request_type))
 
     # Try to find the token from one of these locations. It only needs to exist
     # in one place to be valid (not every location).

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -252,14 +252,14 @@ def _decode_jwt_from_request(request_type):
 
     # add the functions in the order specified in JWT_TOKEN_LOCATION
     for location in locations:
-        if location == 'cookies' and config.jwt_in_cookies:
+        if location == 'cookies':
             get_encoded_token_functions.append(
                 lambda: _decode_jwt_from_cookies(request_type))
-        if location == 'query_string' and config.jwt_in_query_string:
+        if location == 'query_string':
             get_encoded_token_functions.append(_decode_jwt_from_query_string)
-        if location == 'headers' and config.jwt_in_headers:
+        if location == 'headers':
             get_encoded_token_functions.append(_decode_jwt_from_headers)
-        if location == 'json' and config.jwt_in_json:
+        if location == 'json':
             get_encoded_token_functions.append(
                 lambda: _decode_jwt_from_json(request_type))
 

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -247,14 +247,19 @@ def _decode_jwt_from_json(request_type):
 def _decode_jwt_from_request(request_type):
     # All the places we can get a JWT from in this request
     get_encoded_token_functions = []
-    if config.jwt_in_cookies:
-        get_encoded_token_functions.append(lambda: _decode_jwt_from_cookies(request_type))
-    if config.jwt_in_query_string:
-        get_encoded_token_functions.append(_decode_jwt_from_query_string)
-    if config.jwt_in_headers:
-        get_encoded_token_functions.append(_decode_jwt_from_headers)
-    if config.jwt_in_json:
-        get_encoded_token_functions.append(lambda: _decode_jwt_from_json(request_type))
+
+    locations = config.token_location
+
+    # add the functions in the order specified in JWT_TOKEN_LOCATION
+    for location in locations:
+        if location == 'cookies' and config.jwt_in_cookies:
+            get_encoded_token_functions.append(lambda: _decode_jwt_from_cookies(request_type))
+        if location == 'query_string' and config.jwt_in_query_string:
+            get_encoded_token_functions.append(_decode_jwt_from_query_string)
+        if location == 'headers' and config.jwt_in_headers:
+            get_encoded_token_functions.append(_decode_jwt_from_headers)
+        if location == 'json' and config.jwt_in_json:
+            get_encoded_token_functions.append(lambda: _decode_jwt_from_json(request_type))
 
     # Try to find the token from one of these locations. It only needs to exist
     # in one place to be valid (not every location).


### PR DESCRIPTION
I've added the update to run the token validation in the order set in JWT_TOKEN_LOCATION, and this allows a valid token earlier in the list to authenticate the user, and invalid to be ignored if later.

This suits my use case - but perhaps another option could be to require no invalid tokens?

I wrote a couple of tests, and fixed one of the error messages in the existing multiple token location test.

Also, I added a note to the configuration options documentation for JWT_TOKEN_LOCATION