### PR TITLE
Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+version: 2
+
+sphinx:
+  builder: htmldir
+  configuration: docs/conf.py


### PR DESCRIPTION
## A workaround for #267 
This will change the permalinks from `html` to `htmldir`

for example: 
`https://flask-jwt-extended.readthedocs.io/en/latest/installation.html`
will be
`https://flask-jwt-extended.readthedocs.io/en/latest/installation/`

Also you need to build stable manually from the read the docs dashboard