### PR TITLE
Change Pallets-Sphinx-Themes dependency to the latest commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ itsdangerous==1.1.0
 Jinja2==2.10.3
 MarkupSafe==1.1.1
 packaging==19.2
-Pallets-Sphinx-Themes==1.2.2
+Pallets-Sphinx-Themes==1.2.3
 pluggy==0.13.0
 py==1.8.0
 pycparser==2.19


### PR DESCRIPTION
Edit: Upstream was very quick to push the fix, so updated this PR

~There is an exception [1] if you try to execute `make html` in the `docs`
directory if you're using Python 3.8. This was addressed in the
Pallets-Sphinx-Themes repo but there has been no release since then.
Temporarily depend on the latest commit instead of PyPI version.~

~See: https://github.com/pallets/pallets-sphinx-themes/commit/706ed737962b95360a80dcc2e44f03f4a215b883~

~[1]:~

~Exception occurred:
  File "/home/alex/Code/pyenv/versions/3.8.0/lib/python3.8/importlib/metadata.py", line 381, in find_distributions
    found = cls._search_paths(context.pattern, context.path)
AttributeError: 'str' object has no attribute 'pattern'
The full traceback has been saved in /tmp/sphinx-err-5ejlxhto.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:53: html] Error 2~