### PR TITLE
OOP callbacks

### DIFF
--- a/flask_jwt_extended/default_callbacks.py
+++ b/flask_jwt_extended/default_callbacks.py
@@ -11,122 +11,124 @@ from flask import jsonify
 from flask_jwt_extended.config import config
 
 
-def default_user_claims_callback(userdata):
-    """
-    By default, we add no additional claims to the access tokens.
+class DefaultCallbacks:
+    @staticmethod
+    def user_claims(userdata):
+        """
+        By default, we add no additional claims to the access tokens.
 
-    :param userdata: data passed in as the ```identity``` argument to the
-                     ```create_access_token``` and ```create_refresh_token```
-                     functions
-    """
-    return {}
+        :param userdata: data passed in as the ```identity``` argument to the
+                        ```create_access_token``` and ```create_refresh_token```
+                        functions
+        """
+        return {}
 
+    @staticmethod
+    def jwt_headers(default_headers):
+        """
+        By default header typically consists of two parts: the type of the token,
+        which is JWT, and the signing algorithm being used, such as HMAC SHA256
+        or RSA. But we don't set the default header here we set it as empty which
+        further by default set while encoding the token
+        :return: default we set None here
+        """
+        return None
 
-def default_jwt_headers_callback(default_headers):
-    """
-    By default header typically consists of two parts: the type of the token,
-    which is JWT, and the signing algorithm being used, such as HMAC SHA256
-    or RSA. But we don't set the default header here we set it as empty which
-    further by default set while encoding the token
-    :return: default we set None here
-    """
-    return None
+    @staticmethod
+    def user_identity(userdata):
+        """
+        By default, we use the passed in object directly as the jwt identity.
+        See this for additional info:
 
+        :param userdata: data passed in as the ```identity``` argument to the
+                        ```create_access_token``` and ```create_refresh_token```
+                        functions
+        """
+        return userdata
 
-def default_user_identity_callback(userdata):
-    """
-    By default, we use the passed in object directly as the jwt identity.
-    See this for additional info:
+    @staticmethod
+    def expired_token_response(_expired_jwt_header, _expired_jwt_data):
+        """
+        By default, if an expired token attempts to access a protected endpoint,
+        we return a generic error message with a 401 status
+        """
+        return jsonify({config.error_msg_key: "Token has expired"}), 401
 
-    :param userdata: data passed in as the ```identity``` argument to the
-                     ```create_access_token``` and ```create_refresh_token```
-                     functions
-    """
-    return userdata
+    @staticmethod
+    def invalid_token_response(error_string):
+        """
+        By default, if an invalid token attempts to access a protected endpoint, we
+        return the error string for why it is not valid with a 422 status code
 
+        :param error_string: String indicating why the token is invalid
+        """
+        return jsonify({config.error_msg_key: error_string}), 422
 
-def default_expired_token_callback(_expired_jwt_header, _expired_jwt_data):
-    """
-    By default, if an expired token attempts to access a protected endpoint,
-    we return a generic error message with a 401 status
-    """
-    return jsonify({config.error_msg_key: "Token has expired"}), 401
+    @staticmethod
+    def unauthorized_response(error_string):
+        """
+        By default, if a protected endpoint is accessed without a JWT, we return
+        the error string indicating why this is unauthorized, with a 401 status code
 
+        :param error_string: String indicating why this request is unauthorized
+        """
+        return jsonify({config.error_msg_key: error_string}), 401
 
-def default_invalid_token_callback(error_string):
-    """
-    By default, if an invalid token attempts to access a protected endpoint, we
-    return the error string for why it is not valid with a 422 status code
+    @staticmethod
+    def needs_fresh_token_response(jwt_header, jwt_data):
+        """
+        By default, if a non-fresh jwt is used to access a ```fresh_jwt_required```
+        endpoint, we return a general error message with a 401 status code
+        """
+        return jsonify({config.error_msg_key: "Fresh token required"}), 401
 
-    :param error_string: String indicating why the token is invalid
-    """
-    return jsonify({config.error_msg_key: error_string}), 422
+    @staticmethod
+    def revoked_token_response():
+        """
+        By default, if a revoked token is used to access a protected endpoint, we
+        return a general error message with a 401 status code
+        """
+        return jsonify({config.error_msg_key: "Token has been revoked"}), 401
 
+    @staticmethod
+    def user_lookup_error_response(_jwt_header, jwt_data):
+        """
+        By default, if a user_lookup callback is defined and the callback
+        function returns None, we return a general error message with a 401
+        status code
+        """
+        identity = jwt_data[config.identity_claim_key]
+        result = {config.error_msg_key: "Error loading the user {}".format(identity)}
+        return jsonify(result), 401
 
-def default_unauthorized_callback(error_string):
-    """
-    By default, if a protected endpoint is accessed without a JWT, we return
-    the error string indicating why this is unauthorized, with a 401 status code
+    # TODO: Change this to default_token_verification_callback, pass in header and data.
+    @staticmethod
+    def verify_claims(user_claims):
+        """
+        By default, we do not do any verification of the user claims.
+        """
+        return True
 
-    :param error_string: String indicating why this request is unauthorized
-    """
-    return jsonify({config.error_msg_key: error_string}), 401
+    @staticmethod
+    def invalid_claims_response(_jwt_header, _jwt_data):
+        """
+        By default, if the user claims verification failed, we return a generic
+        error message with a 400 status code
+        """
+        return jsonify({config.error_msg_key: "User claims verification failed"}), 400
 
+    @staticmethod
+    def decode_key(claims, headers):
+        """
+        By default, the decode key specified via the JWT_SECRET_KEY or
+        JWT_PUBLIC_KEY settings will be used to decode all tokens
+        """
+        return config.decode_key
 
-def default_needs_fresh_token_callback(jwt_header, jwt_data):
-    """
-    By default, if a non-fresh jwt is used to access a ```fresh_jwt_required```
-    endpoint, we return a general error message with a 401 status code
-    """
-    return jsonify({config.error_msg_key: "Fresh token required"}), 401
-
-
-def default_revoked_token_callback():
-    """
-    By default, if a revoked token is used to access a protected endpoint, we
-    return a general error message with a 401 status code
-    """
-    return jsonify({config.error_msg_key: "Token has been revoked"}), 401
-
-
-def default_user_lookup_error_callback(_jwt_header, jwt_data):
-    """
-    By default, if a user_lookup callback is defined and the callback
-    function returns None, we return a general error message with a 401
-    status code
-    """
-    identity = jwt_data[config.identity_claim_key]
-    result = {config.error_msg_key: "Error loading the user {}".format(identity)}
-    return jsonify(result), 401
-
-
-# TODO: Change this to default_token_verification_callback, pass in header and data.
-def default_claims_verification_callback(user_claims):
-    """
-    By default, we do not do any verification of the user claims.
-    """
-    return True
-
-
-def default_verify_claims_failed_callback(_jwt_header, _jwt_data):
-    """
-    By default, if the user claims verification failed, we return a generic
-    error message with a 400 status code
-    """
-    return jsonify({config.error_msg_key: "User claims verification failed"}), 400
-
-
-def default_decode_key_callback(claims, headers):
-    """
-    By default, the decode key specified via the JWT_SECRET_KEY or
-    JWT_PUBLIC_KEY settings will be used to decode all tokens
-    """
-    return config.decode_key
-
-
-def default_encode_key_callback(identity):
-    """
-    By default, the encode key specified via the JWT_SECRET_KEY or
-    JWT_PRIVATE_KEY settings will be used to encode all tokens
-    """
-    return config.encode_key
+    @staticmethod
+    def encode_key(identity):
+        """
+        By default, the encode key specified via the JWT_SECRET_KEY or
+        JWT_PRIVATE_KEY settings will be used to encode all tokens
+        """
+        return config.encode_key

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -44,6 +44,24 @@ class JWTManager(object):
     to your app in a factory function.
     """
 
+    # register the default error handler callback methods. these can be
+    # overridden with the appropriate loader decorators
+    _claims_verification_callback = staticmethod(default_claims_verification_callback)
+    _decode_key_callback = staticmethod(default_decode_key_callback)
+    _encode_key_callback = staticmethod(default_encode_key_callback)
+    _expired_token_callback = staticmethod(default_expired_token_callback)
+    _invalid_token_callback = staticmethod(default_invalid_token_callback)
+    _jwt_additional_header_callback = staticmethod(default_jwt_headers_callback)
+    _needs_fresh_token_callback = staticmethod(default_needs_fresh_token_callback)
+    _revoked_token_callback = staticmethod(default_revoked_token_callback)
+    _token_in_blacklist_callback = None
+    _unauthorized_callback = staticmethod(default_unauthorized_callback)
+    _user_claims_callback = staticmethod(default_user_claims_callback)
+    _user_identity_callback = staticmethod(default_user_identity_callback)
+    _user_lookup_callback = None
+    _user_lookup_error_callback = staticmethod(default_user_lookup_error_callback)
+    _verify_claims_failed_callback = staticmethod(default_verify_claims_failed_callback)
+
     def __init__(self, app=None):
         """
         Create the JWTManager instance. You can either pass a flask application
@@ -52,24 +70,6 @@ class JWTManager(object):
 
         :param app: A flask application
         """
-        # Register the default error handler callback methods. These can be
-        # overridden with the appropriate loader decorators
-        self._claims_verification_callback = default_claims_verification_callback
-        self._decode_key_callback = default_decode_key_callback
-        self._encode_key_callback = default_encode_key_callback
-        self._expired_token_callback = default_expired_token_callback
-        self._invalid_token_callback = default_invalid_token_callback
-        self._jwt_additional_header_callback = default_jwt_headers_callback
-        self._needs_fresh_token_callback = default_needs_fresh_token_callback
-        self._revoked_token_callback = default_revoked_token_callback
-        self._token_in_blacklist_callback = None
-        self._unauthorized_callback = default_unauthorized_callback
-        self._user_claims_callback = default_user_claims_callback
-        self._user_identity_callback = default_user_identity_callback
-        self._user_lookup_callback = None
-        self._user_lookup_error_callback = default_user_lookup_error_callback
-        self._verify_claims_failed_callback = default_verify_claims_failed_callback
-
         # Register this extension with the flask app now (if it is provided)
         if app is not None:
             self.init_app(app)

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -172,22 +172,22 @@ def create_refresh_token(identity, expires_delta=None, user_claims=None, headers
 
 def has_user_lookup():
     jwt_manager = _get_jwt_manager()
-    return jwt_manager._user_lookup_callback is not None
+    return jwt_manager.lookup_user is not None
 
 
 def user_lookup(*args, **kwargs):
     jwt_manager = _get_jwt_manager()
-    return jwt_manager._user_lookup_callback(*args, **kwargs)
+    return jwt_manager.lookup_user(*args, **kwargs)
 
 
 def has_token_in_blacklist_callback():
     jwt_manager = _get_jwt_manager()
-    return jwt_manager._token_in_blacklist_callback is not None
+    return jwt_manager.token_is_blacklisted is not None
 
 
 def token_in_blacklist(*args, **kwargs):
     jwt_manager = _get_jwt_manager()
-    return jwt_manager._token_in_blacklist_callback(*args, **kwargs)
+    return jwt_manager.token_is_blacklisted(*args, **kwargs)
 
 
 def verify_token_type(decoded_token, expected_type):
@@ -214,7 +214,7 @@ def verify_token_not_blacklisted(decoded_token, request_type):
 
 def _verify_token_claims(jwt_header, jwt_data):
     jwt_manager = _get_jwt_manager()
-    if not jwt_manager._claims_verification_callback(jwt_data):
+    if not jwt_manager.verify_claims(jwt_data):
         error_msg = "User claims verification failed"
         raise UserClaimsVerificationError(error_msg, jwt_header, jwt_data)
 

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -165,20 +165,20 @@ def test_encode_decode_callback_values(app, default_access_token):
     jwtM = get_jwt_manager(app)
     app.config["JWT_SECRET_KEY"] = "foobarbaz"
     with app.test_request_context():
-        assert jwtM._decode_key_callback({}, {}) == "foobarbaz"
-        assert jwtM._encode_key_callback({}) == "foobarbaz"
+        assert jwtM.decode_key({}, {}) == "foobarbaz"
+        assert jwtM.encode_key({}) == "foobarbaz"
 
     @jwtM.encode_key_loader
     def get_encode_key_1(identity):
         return "different secret"
 
-    assert jwtM._encode_key_callback("") == "different secret"
+    assert jwtM.encode_key("") == "different secret"
 
     @jwtM.decode_key_loader
     def get_decode_key_1(claims, headers):
         return "different secret"
 
-    assert jwtM._decode_key_callback({}, {}) == "different secret"
+    assert jwtM.decode_key({}, {}) == "different secret"
 
 
 def test_custom_encode_decode_key_callbacks(app, default_access_token):

--- a/tests/test_oop_callbacks.py
+++ b/tests/test_oop_callbacks.py
@@ -1,0 +1,38 @@
+import pytest
+from flask import Flask
+from flask import jsonify
+
+from flask_jwt_extended import create_access_token
+from flask_jwt_extended import get_jwt
+from flask_jwt_extended import jwt_required
+from flask_jwt_extended import JWTManager as JWTManager_
+from tests.utils import make_headers
+
+
+class JWTManager(JWTManager_):
+    def _user_claims_callback(self, identity):
+        return {"foo": "bar"}
+
+
+@pytest.fixture(scope="function")
+def app():
+    app = Flask(__name__)
+    app.config["JWT_SECRET_KEY"] = "foobarbaz"
+    JWTManager(app)
+
+    @app.route("/protected", methods=["GET"])
+    @jwt_required()
+    def get_claims():
+        return jsonify(get_jwt())
+
+    return app
+
+
+def test_user_claim_in_access_token(app):
+    with app.test_request_context():
+        access_token = create_access_token("username")
+
+    test_client = app.test_client()
+    response = test_client.get("/protected", headers=make_headers(access_token))
+    assert response.get_json()["foo"] == "bar"
+    assert response.status_code == 200

--- a/tests/test_oop_callbacks.py
+++ b/tests/test_oop_callbacks.py
@@ -10,7 +10,7 @@ from tests.utils import make_headers
 
 
 class JWTManager(JWTManager_):
-    def _user_claims_callback(self, identity):
+    def user_claims(self, identity):
         return {"foo": "bar"}
 
 


### PR DESCRIPTION
Here is an attempt to implement #333 .

The first commit is the minimal change needed. The second commit turns things completely around and makes all the default implementations static methods of a class that can be inherited.

I’m still a bit unhappy about the method names and open for suggestions.

Other improvements that came to my mind when I was working on this:

- Completely merge the default implementations into the JWTManager class, because … why not?
- `JWTManager.token_is_blacklisted()` could get a default implementation that always returns `False` then we could remove `has_token_in_blacklist_callback()`.