### PR TITLE
Add JWT_VERIFY_AUDIENCE option

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -58,6 +58,10 @@ General Options:
                                   not very far. This leeway is used for `nbf` (“not before”) and `exp`
                                   (“expiration time”).
                                   Defaults to ``0``
+``JWT_VERIFY_AUDIENCE``           Whether audience should be verified when decoding.  Use when you need
+                                  to skip verification regardless of the value in the token.  If you
+                                  need to explicitly verify that ``aud`` is not set, use ``JWT_DECODE_AUDIENCE=None``.
+                                  Defaults to ``True``.
 ================================= =========================================
 
 

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -331,5 +331,9 @@ class _Config(object):
     def leeway(self):
         return current_app.config["JWT_DECODE_LEEWAY"]
 
+    @property
+    def verify_audience(self):
+        return current_app.config["JWT_VERIFY_AUDIENCE"]
+
 
 config = _Config()

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -198,6 +198,7 @@ class JWTManager(object):
         app.config.setdefault("JWT_SECRET_KEY", None)
         app.config.setdefault("JWT_SESSION_COOKIE", True)
         app.config.setdefault("JWT_TOKEN_LOCATION", ("headers",))
+        app.config.setdefault("JWT_VERIFY_AUDIENCE", True)
 
     def additional_headers_loader(self, callback):
         """
@@ -489,6 +490,7 @@ class JWTManager(object):
             "issuer": config.issuer,
             "leeway": config.leeway,
             "secret": secret,
+            "verify_aud": config.verify_audience,
         }
 
         try:

--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -61,12 +61,14 @@ def _decode_jwt(
     issuer,
     leeway,
     secret,
+    verify_aud,
 ):
-    options = {}
+    options = {"verify_aud": verify_aud}
     if allow_expired:
         options["verify_exp"] = False
 
-    # This call verifies the ext, iat, nbf, and aud claims
+    # This call verifies the ext, iat, and nbf claims
+    # This optionally verifies the exp and aud claims if enabled
     decoded_token = jwt.decode(
         encoded_token,
         secret,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,7 @@ def test_default_configs(app):
         assert config.json_encoder is app.json_encoder
 
         assert config.error_msg_key == "msg"
+        assert config.verify_audience is True
 
 
 @pytest.mark.parametrize("delta_func", [timedelta, relativedelta])

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -233,6 +233,18 @@ def test_invalid_aud(app, default_access_token, token_aud):
             decode_token(invalid_token)
 
 
+@pytest.mark.parametrize("token_aud", ["bar", ["bar"], ["bar", "baz"]])
+def test_verify_aud(app, default_access_token, token_aud):
+    app.config["JWT_DECODE_AUDIENCE"] = "foo"
+    app.config["JWT_VERIFY_AUDIENCE"] = False
+
+    default_access_token["aud"] = token_aud
+    valid_token = encode_token(app, default_access_token)
+    with app.test_request_context():
+        decoded = decode_token(valid_token)
+        assert decoded["aud"] == token_aud
+
+
 def test_valid_iss(app, default_access_token):
     app.config["JWT_DECODE_ISSUER"] = "foobar"
 


### PR DESCRIPTION
This carries the previous PR #228 with updates to work with the 4.0.0-dev branch.

Adds an option to disable `aud` (audience) validation.  This can be helpful in cases where you need to accept tokens that may sometimes have `aud` present (in my case I want to start including `aud` on new tokens but continue to accept the old tokens for a period of time while I migrate those).