### PR TITLE
Add jwt_header and jwt_data to user_lookup_loader callback

### DIFF
--- a/4.0.0_changelog.md
+++ b/4.0.0_changelog.md
@@ -64,6 +64,16 @@ Breaking Changes
       return jsonify(msg="Yo {} you need a fresh token".format(jwt_data['sub']), 401)
   ```
 
+* The callback function for `user_lookup_loader` no longer takes `identity`
+  as an argument. Instead it takes `jwt_header` and `jwt_data`:
+
+  ```python
+  @user_lookup_loader
+  def handle_user_lookup(_jwt_header, jwt_data):
+      identity = jwt_data['sub']
+      return UserObject(username=identity)
+  ```
+
 * The callback function for `user_lookup_error_loader` no longer takes `identity`
   as an argument. Instead it takes `jwt_header` and `jwt_data`:
 

--- a/examples/complex_objects_from_tokens.py
+++ b/examples/complex_objects_from_tokens.py
@@ -27,12 +27,13 @@ users_to_roles = {"foo": ["admin"], "bar": ["peasant"], "baz": ["peasant"]}
 
 # This function is called whenever a protected endpoint is accessed,
 # and must return an object based on the tokens identity.
-# This is called after the token is verified, so you can use
-# get_jwt() in here if desired. Note that this needs to
+# This is called after the token is verified, so you can safely
+# use the claims passed in. Note that this needs to
 # return None if the user could not be loaded for any reason,
 # such as not being found in the underlying data store
 @jwt.user_lookup_loader
-def user_lookup_callback(identity):
+def user_lookup_callback(_jwt_header, jwt_data):
+    identity = jwt_data["sub"]
     if identity not in users_to_roles:
         return None
 
@@ -43,11 +44,10 @@ def user_lookup_callback(identity):
 # user_lookup_callback returns None. If you don't override
 # this, # it will return a 401 status code with the JSON:
 # {"msg": "Error loading the user <identity>"}.
-# You can use # get_jwt() here too if desired
 @jwt.user_lookup_error_loader
-def custom_user_lookup_error(identity):
-    ret = {"msg": "User {} not found".format(identity)}
-    return jsonify(ret), 404
+def custom_user_lookup_error(_jwt_header, jwt_data):
+    identity = jwt_data["sub"]
+    return jsonify(msg="{} not found".format(identity)), 401
 
 
 # Create a token for any user, so this can be tested out

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -407,9 +407,9 @@ class JWTManager(object):
         automatically load an object when a protected endpoint is accessed.
         By default this is not used.
 
-        *HINT*: The callback must take **one** argument which is the identity JWT
-        accessing the protected endpoint, and it must return any object (which can
-        then be accessed via the :attr:`~flask_jwt_extended.current_user` LocalProxy
+        *HINT*: The callback must take **two** arguments which are the headers and claims
+        of the JWT accessing the protected endpoint, and it must return any object (which
+        can then be accessed via the :attr:`~flask_jwt_extended.current_user` LocalProxy
         in the protected endpoint), or `None` in the case of a user not being
         able to be loaded for any reason. If this callback function returns
         `None`, the :meth:`~flask_jwt_extended.JWTManager.user_lookup_error_loader`

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -95,7 +95,7 @@ def _load_user(jwt_header, jwt_data):
         return None
 
     identity = jwt_data[config.identity_claim_key]
-    user = user_lookup(identity)
+    user = user_lookup(jwt_header, jwt_data)
     if user is None:
         error_msg = "user_lookup returned None for {}".format(identity)
         raise UserLookupError(error_msg, jwt_header, jwt_data)

--- a/tests/test_user_lookup.py
+++ b/tests/test_user_lookup.py
@@ -35,8 +35,8 @@ def test_load_valid_user(app, url):
     jwt = get_jwt_manager(app)
 
     @jwt.user_lookup_loader
-    def user_lookup_callback(identity):
-        return {"username": identity}
+    def user_lookup_callback(_jwt_header, jwt_data):
+        return {"username": jwt_data["sub"]}
 
     test_client = app.test_client()
     with app.test_request_context():
@@ -52,7 +52,7 @@ def test_load_invalid_user(app, url):
     jwt = get_jwt_manager(app)
 
     @jwt.user_lookup_loader
-    def user_lookup_callback(identity):
+    def user_lookup_callback(_jwt_header, jwt_data):
         return None
 
     test_client = app.test_client()
@@ -69,7 +69,7 @@ def test_custom_user_lookup_errors(app, url):
     jwt = get_jwt_manager(app)
 
     @jwt.user_lookup_loader
-    def user_lookup_callback(identity):
+    def user_lookup_callback(_jwt_header, jwt_data):
         return None
 
     @jwt.user_lookup_error_loader


### PR DESCRIPTION
As mentioned in https://github.com/vimalloc/flask-jwt-extended/issues/327, this replaces identity with jwt_header and jwt_data in the user_lookup_loader callback.  This allows access to the token data in the callback since we're not relying on the global state anymore.