### PR TITLE
Bump werkzeug from 0.16.0 to. 1.0.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ author = u"Landon Gilbert-Bland"
 # built documents.
 #
 with io.open("../flask_jwt_extended/__init__.py", encoding="utf-8") as f:
-    package_version = re.search(r"__version__ = '(.+)'", f.read()).group(1)
+    package_version = re.search(r"__version__ = \"(.+)\"", f.read()).group(1)
 version = package_version
 release = package_version
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -108,14 +108,18 @@ These are only applicable if ``JWT_TOKEN_LOCATION`` is set to use cookies.
                                   for only the paths that need the refresh cookie
 ``JWT_COOKIE_SECURE``             If the secure flag should be set on your JWT cookies. This will only allow
                                   the cookies to be sent over https. Defaults to ``False``, but in production
-                                  this should likely be set to ``True``.
+                                  this should likely be set to ``True``. To set ``SameSite=None``, this option must be set to ``True``.
 ``JWT_COOKIE_DOMAIN``             Value to use for cross domain cookies. Defaults to ``None`` which sets
                                   this cookie to only be readable by the domain that set it.
 ``JWT_SESSION_COOKIE``            If the cookies should be session cookies (deleted when the
                                   browser is closed) or persistent cookies (never expire).
                                   Defaults to ``True`` (session cookies).
 ``JWT_COOKIE_SAMESITE``           If the cookies should be sent in a cross-site browsing context.
-                                  Defaults to ``None``, which means cookies are always sent.
+                                  Defaults to ``None``, which means cookies will be treated as ``SameSite=Lax``.
+                                  For more detail of default behavior of SameSite,
+                                  check the `IETF proposal <https://tools.ietf.org/html/draft-west-cookie-incrementalism-00>`_
+                                  and `MDN docs <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite>`_.
+                                  If you want to set ``SameSite=None``, this option must be set to ``'None'`` explicitly (as string) with ``JWT_COOKIE_SECURE=True``.
 ``JWT_COOKIE_CSRF_PROTECT``       Enable/disable CSRF protection when using cookies. Defaults to ``True``.
 ================================= =========================================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,6 @@ tox==3.14.0
 typed-ast==1.4.0
 urllib3==1.25.7
 virtualenv==16.7.7
-Werkzeug==0.16.0
+Werkzeug==1.0.1
 wrapt==1.11.2
 zipp==0.6.0


### PR DESCRIPTION
Resolve #350 

## Changes
- Upgraded werkzeug to 1.0.1
- Updated documents for `JWT_COOKIE_SECURE` and `JWT_COOKIE_SAMESITE`
- etc: `docs/conf.py` - revised pattern string to properly read version info

I just updated werkzeug and documents. Actually there are no code changes, following default arguments of werkzeug's [`dump_cookie`](https://github.com/pallets/werkzeug/blob/1.0.x/src/werkzeug/http.py#L1137) function. (Defaults to `None`, and let browser implicitly set cookie with `SameSite=Lax`) But we can also change default value of `JWT_COOKIE_SAMESITE ` to `'None'` (as string). (In this case, `JWT_COOKIE_SECURE ` also has to be `True`.)

Which one does look good to you? 