### PR TITLE
CRSF verification in cookies - Added

### DIFF
--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -185,6 +185,10 @@ class _Config(object):
                current_app.config['JWT_REFRESH_CSRF_HEADER_NAME']
 
     @property
+    def csrf_check_cookies(self):
+        return current_app.config['JWT_CSRF_CHECK_COOKIES']
+
+    @property
     def csrf_check_form(self):
         return current_app.config['JWT_CSRF_CHECK_FORM']
 

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -198,7 +198,7 @@ class JWTManager(object):
         app.config.setdefault('JWT_REFRESH_CSRF_COOKIE_NAME', 'csrf_refresh_token')
         app.config.setdefault('JWT_ACCESS_CSRF_COOKIE_PATH', '/')
         app.config.setdefault('JWT_REFRESH_CSRF_COOKIE_PATH', '/')
-        app.config.setdefault('JWT_CSRF_CHECK_COOKIES', True)
+        app.config.setdefault('JWT_CSRF_CHECK_COOKIES', False)
         app.config.setdefault('JWT_CSRF_CHECK_FORM', False)
         app.config.setdefault('JWT_ACCESS_CSRF_FIELD_NAME', 'csrf_token')
         app.config.setdefault('JWT_REFRESH_CSRF_FIELD_NAME', 'csrf_token')

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -198,6 +198,7 @@ class JWTManager(object):
         app.config.setdefault('JWT_REFRESH_CSRF_COOKIE_NAME', 'csrf_refresh_token')
         app.config.setdefault('JWT_ACCESS_CSRF_COOKIE_PATH', '/')
         app.config.setdefault('JWT_REFRESH_CSRF_COOKIE_PATH', '/')
+        app.config.setdefault('JWT_CSRF_CHECK_COOKIES', True)
         app.config.setdefault('JWT_CSRF_CHECK_FORM', False)
         app.config.setdefault('JWT_ACCESS_CSRF_FIELD_NAME', 'csrf_token')
         app.config.setdefault('JWT_REFRESH_CSRF_FIELD_NAME', 'csrf_token')

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -215,10 +215,12 @@ def _decode_jwt_from_cookies(request_type):
         cookie_key = config.access_cookie_name
         csrf_header_key = config.access_csrf_header_name
         csrf_field_key = config.access_csrf_field_name
+        csrf_cookie_name = config.access_csrf_cookie_name
     else:
         cookie_key = config.refresh_cookie_name
         csrf_header_key = config.refresh_csrf_header_name
         csrf_field_key = config.refresh_csrf_field_name
+        csrf_cookie_name = config.refresh_csrf_cookie_name
 
     encoded_token = request.cookies.get(cookie_key)
     if not encoded_token:
@@ -226,6 +228,8 @@ def _decode_jwt_from_cookies(request_type):
 
     if config.csrf_protect and request.method in config.csrf_request_methods:
         csrf_value = request.headers.get(csrf_header_key, None)
+        if not csrf_value and config.csrf_check_cookies:
+            csrf_value = request.cookies.get(csrf_cookie_name, None)
         if not csrf_value and config.csrf_check_form:
             csrf_value = request.form.get(csrf_field_key, None)
         if not csrf_value:

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -244,6 +244,26 @@ def test_csrf_with_custom_form_field(app, options):
 
 
 @pytest.mark.parametrize("options", [
+    ('/refresh_token', 'csrf_refresh_token', '/post_refresh_protected'),
+    ('/access_token', 'csrf_access_token', '/post_protected')
+])
+def test_csrf_with_default_cookie_field(app, options):
+    app.config['JWT_CSRF_CHECK_COOKIES'] = True
+    test_client = app.test_client()
+    auth_url, csrf_cookie_name, post_url = options
+
+    # Get the jwt cookies and csrf double submit tokens
+    response = test_client.get(auth_url)
+    csrf_token = _get_cookie_from_response(response, csrf_cookie_name)[csrf_cookie_name]
+
+    # Test that you can post with the csrf double submit value
+    test_client.set_cookie(csrf_cookie_name, csrf_token)
+    response = test_client.post(post_url)
+    assert response.status_code == 200
+    assert response.get_json() == {'foo': 'bar'}
+
+
+@pytest.mark.parametrize("options", [
     ('/refresh_token', 'csrf_refresh_token', '/refresh_protected', '/post_refresh_protected'),  # nopep8
     ('/access_token', 'csrf_access_token', '/protected', '/post_protected')
 ])


### PR DESCRIPTION
### What does this PR do?

The changes I propose allow you to search cookies for the CSRF token associated with a request to the server.

### Previous Behavior

The search for the CSRF token is performed exclusively in the Headers or form data associated with a client request. This behavior also occurs when the access, refresh and CSRF token are sent via cookies.

Since in the browser with javascript it is not possible to access the *HttpOnly* cookies to fetch the CSRF token to build the X-CSRF-TOKEN header, the verification of the CSRF by the server will always be nullified.

### New Behavior

The search for the CSRF token occurs first in the headers, then in the cookies and finally in the form data of a request to the server.