### PR TITLE
remove .decode() from return of jwt.encode()

### DIFF
--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -27,7 +27,7 @@ def _encode_jwt(additional_token_data, expires_delta, secret, algorithm,
         token_data['exp'] = now + expires_delta
     token_data.update(additional_token_data)
     encoded_token = jwt.encode(token_data, secret, algorithm,
-                               json_encoder=json_encoder, headers=headers).decode('utf-8')
+                               json_encoder=json_encoder, headers=headers)
     return encoded_token
 
 


### PR DESCRIPTION
Resolves issue #377, #378. 

I didn't see issue #377 until after I had created #378 as it had been closed.