### PR TITLE
Support JWT types other than refresh and access

### DIFF
--- a/flask_jwt_extended/internal_utils.py
+++ b/flask_jwt_extended/internal_utils.py
@@ -25,12 +25,14 @@ def user_lookup(*args, **kwargs):
     return jwt_manager._user_lookup_callback(*args, **kwargs)
 
 
-def verify_token_type(decoded_token, expected_type):
-    if decoded_token["type"] != expected_type:
-        raise WrongTokenError("Only {} tokens are allowed".format(expected_type))
+def verify_token_type(decoded_token, refresh):
+    if not refresh and decoded_token["type"] == "refresh":
+        raise WrongTokenError("Only non-refresh tokens are allowed")
+    elif refresh and decoded_token["type"] != "refresh":
+        raise WrongTokenError("Only refresh tokens are allowed")
 
 
-def verify_token_not_blocklisted(jwt_header, jwt_data, request_type):
+def verify_token_not_blocklisted(jwt_header, jwt_data):
     jwt_manager = get_jwt_manager()
     if jwt_manager._token_in_blocklist_callback(jwt_header, jwt_data):
         raise RevokedTokenError(jwt_header, jwt_data)

--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -98,9 +98,6 @@ def _decode_jwt(
     if "type" not in decoded_token:
         decoded_token["type"] = "access"
 
-    if decoded_token["type"] not in ("access", "refresh"):
-        raise JWTDecodeError("Invalid token type: {}".format(decoded_token["type"]))
-
     if "fresh" not in decoded_token:
         decoded_token["fresh"] = False
 

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -70,13 +70,13 @@ def test_default_decode_token_values(app, default_access_token):
         assert decoded["fresh"] is False
 
 
-def test_bad_token_type(app, default_access_token):
-    default_access_token["type"] = "banana"
-    bad_type_token = encode_token(app, default_access_token)
+def test_supports_decoding_other_token_types(app, default_access_token):
+    default_access_token["type"] = "app"
+    other_token = encode_token(app, default_access_token)
 
-    with pytest.raises(JWTDecodeError):
-        with app.test_request_context():
-            decode_token(bad_type_token)
+    with app.test_request_context():
+        decoded = decode_token(other_token)
+        assert decoded["type"] == "app"
 
 
 def test_encode_decode_audience(app):

--- a/tests/test_view_decorators.py
+++ b/tests/test_view_decorators.py
@@ -72,7 +72,7 @@ def test_jwt_required(app):
     # Test refresh token access to jwt_required
     response = test_client.get(url, headers=make_headers(refresh_token))
     assert response.status_code == 422
-    assert response.get_json() == {"msg": "Only access tokens are allowed"}
+    assert response.get_json() == {"msg": "Only non-refresh tokens are allowed"}
 
 
 def test_fresh_jwt_required(app):
@@ -113,7 +113,7 @@ def test_fresh_jwt_required(app):
 
     response = test_client.get(url, headers=make_headers(refresh_token))
     assert response.status_code == 422
-    assert response.get_json() == {"msg": "Only access tokens are allowed"}
+    assert response.get_json() == {"msg": "Only non-refresh tokens are allowed"}
 
     # Test with custom response
     @jwtM.needs_fresh_token_loader
@@ -176,7 +176,7 @@ def test_jwt_optional(app, delta_func):
 
     response = test_client.get(url, headers=make_headers(refresh_token))
     assert response.status_code == 422
-    assert response.get_json() == {"msg": "Only access tokens are allowed"}
+    assert response.get_json() == {"msg": "Only non-refresh tokens are allowed"}
 
     response = test_client.get(url, headers=None)
     assert response.status_code == 200


### PR DESCRIPTION
My team use the Cloudflare Team's identity service to authenticate and pass JWT tokens to our apps. We've been attempting to use flask-jwt-extended to verify JWT tokens within our flask apps, but have run into a bit of a problem. There seems to be an assumption that the only token types that can be used are `refresh` or `access` tokens, but Cloudflare at least sets `"type": "app"` within the payload. I haven't been able to find a spec anywhere that says only `access` and `refresh` are valid, and regardless Cloudflare obviously uses a different value. 

Here's a PR to alter the library to support more token types. All tests are passing, but there may be some changes that merit more thought, I'm happy to take suggestions.