### PR TITLE
Add option to disable NBF claim during ecoding

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -142,6 +142,13 @@ General Options:
     Default: ``None``
 
 
+.. py:data:: JWT_ENCODE_NBR
+
+    The not before (``nbf``) claim which defines that a JWT MUST NOT be accepted for processing during decode.
+
+    Default: ``True``
+
+
 .. py:data:: JWT_DECODE_LEEWAY
 
     The number of seconds a token will be considered valid before the Not Before

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -142,7 +142,7 @@ General Options:
     Default: ``None``
 
 
-.. py:data:: JWT_ENCODE_NBR
+.. py:data:: JWT_ENCODE_NBF
 
     The not before (``nbf``) claim which defines that a JWT MUST NOT be accepted for processing during decode.
 

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -295,4 +295,5 @@ class _Config(object):
     def encode_nbf(self):
         return current_app.config["JWT_ENCODE_NBF"]
 
+
 config = _Config()

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -291,5 +291,8 @@ class _Config(object):
     def leeway(self):
         return current_app.config["JWT_DECODE_LEEWAY"]
 
+    @property
+    def encode_nbf(self):
+        return current_app.config["JWT_ENCODE_NBF"]
 
 config = _Config()

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -202,6 +202,7 @@ class JWTManager(object):
         app.config.setdefault("JWT_SECRET_KEY", None)
         app.config.setdefault("JWT_SESSION_COOKIE", True)
         app.config.setdefault("JWT_TOKEN_LOCATION", ("headers",))
+        app.config.setdefault("JWT_ENCODE_NBF", True)
 
     def additional_claims_loader(self, callback):
         """
@@ -499,6 +500,7 @@ class JWTManager(object):
             json_encoder=config.json_encoder,
             secret=self._encode_key_callback(identity),
             token_type=token_type,
+            nbf=config.encode_nbf,
         )
 
     def _decode_jwt_from_config(

--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -24,6 +24,7 @@ def _encode_jwt(
     json_encoder,
     secret,
     token_type,
+    nbf,
 ):
     now = datetime.now(timezone.utc)
 
@@ -34,10 +35,12 @@ def _encode_jwt(
         "fresh": fresh,
         "iat": now,
         "jti": str(uuid.uuid4()),
-        "nbf": now,
         "type": token_type,
         identity_claim_key: identity,
     }
+
+    if nbf:
+        token_data["nbf"] = now
 
     if csrf:
         token_data["csrf"] = str(uuid.uuid4())

--- a/tests/test_claims_verification.py
+++ b/tests/test_claims_verification.py
@@ -3,6 +3,7 @@ from flask import Flask
 from flask import jsonify
 
 from flask_jwt_extended import create_access_token
+from flask_jwt_extended import decode_token
 from flask_jwt_extended import jwt_required
 from flask_jwt_extended import JWTManager
 from tests.utils import get_jwt_manager

--- a/tests/test_claims_verification.py
+++ b/tests/test_claims_verification.py
@@ -3,7 +3,6 @@ from flask import Flask
 from flask import jsonify
 
 from flask_jwt_extended import create_access_token
-from flask_jwt_extended import decode_token
 from flask_jwt_extended import jwt_required
 from flask_jwt_extended import JWTManager
 from tests.utils import get_jwt_manager

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -350,3 +350,18 @@ def test_token_expires_time(app):
         # the tokens are created
         assert (access_timestamp - (now_timestamp + 3600)) < 2
         assert (refresh_timestamp - (now_timestamp + 7200)) < 2
+
+
+def test_nbf_is_present_by_default(app):
+    with app.test_request_context():
+        access_token = create_access_token("username", fresh=True)
+        decoded = decode_token(access_token)
+        assert 'nbf' in decoded
+
+
+def test_disable_nbf_encoding(app):
+    app.config["JWT_ENCODE_NBF"] = False
+    with app.test_request_context():
+        access_token = create_access_token("username", fresh=True)
+        decoded = decode_token(access_token)
+        assert 'nbf' not in decoded

--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -356,7 +356,7 @@ def test_nbf_is_present_by_default(app):
     with app.test_request_context():
         access_token = create_access_token("username", fresh=True)
         decoded = decode_token(access_token)
-        assert 'nbf' in decoded
+        assert "nbf" in decoded
 
 
 def test_disable_nbf_encoding(app):
@@ -364,4 +364,4 @@ def test_disable_nbf_encoding(app):
     with app.test_request_context():
         access_token = create_access_token("username", fresh=True)
         decoded = decode_token(access_token)
-        assert 'nbf' not in decoded
+        assert "nbf" not in decoded


### PR DESCRIPTION
Since the [JWT RFC](https://tools.ietf.org/html/rfc7519#section-4.1.5) states that the 'use of this claim is OPTIONAL' and @vimalloc (at #384) was inclined to add this feature, I took the liberty to hack together a possible solution.

I also updated in this merge request the documentation and added test cases for both scenarios.

Hope this comes useful.