### PR TITLE
Added async support to jwt_required view decorator

### DIFF
--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -4,6 +4,7 @@ from functools import wraps
 from re import split
 
 from flask import _request_ctx_stack
+from flask import current_app
 from flask import request
 from werkzeug.exceptions import BadRequest
 
@@ -118,7 +119,7 @@ def jwt_required(optional=False, fresh=False, refresh=False, locations=None):
         @wraps(fn)
         def decorator(*args, **kwargs):
             verify_jwt_in_request(optional, fresh, refresh, locations)
-            return fn(*args, **kwargs)
+            return current_app.ensure_sync(fn)(*args, **kwargs)
 
         return decorator
 


### PR DESCRIPTION
Now that Flask 2, which added Async/Await support, has been released extensions that provide decorators need to be updated in order to be used with Async/Await routes as per the documentation [here](https://flask.palletsprojects.com/en/2.0.x/async-await/#extensions)

I've add the `flask.Flask.ensure_sync()` method to the `@jwt_required` decorator so that it now can be used on Async/Await routes. If this is not added, a coroutine will be returned which in turn will cause Flask to return a `TypeError`.