### PR TITLE
Fix/support flask 2 and flask 1

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,4 +21,6 @@ jobs:
       - name: Install Dependencies
         run: pip install tox
       - name: Run Tox
-        run: tox
+        run: tox -e py
+      - name: Run Tox Flask 1
+        run: tox -e flask1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Dependencies
         run: pip install tox
       - name: Run Tox
-        run: tox -e py
+        run: tox

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -121,12 +121,12 @@ def jwt_required(optional=False, fresh=False, refresh=False, locations=None):
             verify_jwt_in_request(optional, fresh, refresh, locations)
 
             # Compatibility with flask < 2.0
-            try:
+            if hasattr(current_app, "ensure_sync") and callable(
+                getattr(current_app, "ensure_sync", None)
+            ):
                 return current_app.ensure_sync(fn)(*args, **kwargs)
-            except AttributeError as e:  # pragma: no cover
-                if str(e) != "'Flask' object has no attribute 'ensure_sync'":
-                    raise
-                return fn(*args, **kwargs)
+
+            return fn(*args, **kwargs)  # pragma: no cover
 
         return decorator
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36,py37,py38,py39,pypy3,coverage,style,docs
+envlist = py36,py37,py38,py39,pypy3,flask1,coverage,style,docs
 
 [testenv]
 commands =
@@ -13,6 +13,7 @@ deps =
   pytest
   cryptography
   python-dateutil
+  flask1: flask == 1.1.4
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
I took a first stab at making the check for the major Flask version more robust. I've also specified a new test environment in tox which specifically uses Flask 1.1.4, the last major 1.x.x version.