### PR TITLE
Added support for custom JWT types

### DIFF
--- a/flask_jwt_extended/__init__.py
+++ b/flask_jwt_extended/__init__.py
@@ -1,5 +1,6 @@
 from .jwt_manager import JWTManager
 from .utils import create_access_token
+from .utils import create_custom_token
 from .utils import create_refresh_token
 from .utils import current_user
 from .utils import decode_token

--- a/flask_jwt_extended/internal_utils.py
+++ b/flask_jwt_extended/internal_utils.py
@@ -29,7 +29,7 @@ def verify_token_type(decoded_token, refresh, token_type):
     if refresh and decoded_token["type"] != "refresh":
         raise WrongTokenError("Only refresh tokens are allowed")
     elif not refresh and decoded_token["type"] != token_type:
-        raise WrongTokenError(f"Token is not of type {token_type}")
+        raise WrongTokenError(f"Token of type { decoded_token['type'] } is not allowed")
 
 
 def verify_token_not_blocklisted(jwt_header, jwt_data):

--- a/flask_jwt_extended/internal_utils.py
+++ b/flask_jwt_extended/internal_utils.py
@@ -25,11 +25,11 @@ def user_lookup(*args, **kwargs):
     return jwt_manager._user_lookup_callback(*args, **kwargs)
 
 
-def verify_token_type(decoded_token, refresh):
-    if not refresh and decoded_token["type"] == "refresh":
-        raise WrongTokenError("Only non-refresh tokens are allowed")
-    elif refresh and decoded_token["type"] != "refresh":
+def verify_token_type(decoded_token, refresh, token_type):
+    if refresh and decoded_token["type"] != "refresh":
         raise WrongTokenError("Only refresh tokens are allowed")
+    elif not refresh and decoded_token["type"] != token_type:
+        raise WrongTokenError(f"Token is not of type {token_type}")
 
 
 def verify_token_not_blocklisted(jwt_header, jwt_data):

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -487,10 +487,10 @@ class JWTManager(object):
             claim_overrides.update(claims)
 
         if expires_delta is None:
-            if token_type == "access":
-                expires_delta = config.access_expires
-            else:
+            if token_type == "refresh":
                 expires_delta = config.refresh_expires
+            else:
+                expires_delta = config.access_expires
 
         return _encode_jwt(
             algorithm=config.algorithm,

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -222,6 +222,7 @@ def create_refresh_token(
 def create_custom_token(
     identity,
     token_type,
+    fresh=False,
     expires_delta=None,
     additional_claims=None,
     additional_headers=None,
@@ -263,7 +264,7 @@ def create_custom_token(
     return jwt_manager._encode_jwt_from_config(
         claims=additional_claims,
         expires_delta=expires_delta,
-        fresh=False,
+        fresh=fresh,
         headers=additional_headers,
         identity=identity,
         token_type=token_type,

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -219,6 +219,57 @@ def create_refresh_token(
     )
 
 
+def create_custom_token(
+    identity,
+    token_type,
+    expires_delta=None,
+    additional_claims=None,
+    additional_headers=None,
+):
+    """
+    Create a new custom token, with a manually specified type.
+
+    :param identity:
+        The identity of this token. It can be any data that is json serializable.
+        You can use :meth:`~flask_jwt_extended.JWTManager.user_identity_loader`
+        to define a callback function to convert any object passed in into a json
+        serializable format.
+
+    :param token_type:
+        The type of this token. A string such as "refresh" or "access" that specifies
+        the type and purpose of this token.
+
+    :param expires_delta:
+        A ``datetime.timedelta`` for how long this token should last before it expires.
+        Set to False to disable expiration. If this is None, it will use the
+        ``JWT_REFRESH_TOKEN_EXPIRES`` config value (see :ref:`Configuration Options`)
+
+    :param additional_claims:
+        Optional. A hash of claims to include in the refresh token. These claims are
+        merged into the default claims (exp, iat, etc) and claims returned from the
+        :meth:`~flask_jwt_extended.JWTManager.additional_claims_loader` callback.
+        On conflict, these claims take presidence.
+
+    :param headers:
+        Optional. A hash of headers to include in the refresh token. These headers
+        are merged into the default headers (alg, typ) and headers returned from the
+        :meth:`~flask_jwt_extended.JWTManager.additional_headers_loader` callback.
+        On conflict, these headers take presidence.
+
+    :return:
+        An encoded refresh token
+    """
+    jwt_manager = get_jwt_manager()
+    return jwt_manager._encode_jwt_from_config(
+        claims=additional_claims,
+        expires_delta=expires_delta,
+        fresh=False,
+        headers=additional_headers,
+        identity=identity,
+        token_type=token_type,
+    )
+
+
 def get_unverified_jwt_headers(encoded_token):
     """
     Returns the Headers of an encoded JWT without verifying the signature of the JWT.

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -69,8 +69,9 @@ def verify_jwt_in_request(
 
     try:
         if refresh:
+            token_type = "refresh"
             jwt_data, jwt_header, jwt_location = _decode_jwt_from_request(
-                locations, fresh, refresh=True
+                locations, fresh, refresh=True, token_type=token_type
             )
         else:
             jwt_data, jwt_header, jwt_location = _decode_jwt_from_request(

--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -35,7 +35,9 @@ def _verify_token_is_fresh(jwt_header, jwt_data):
             raise FreshTokenRequired("Fresh token required", jwt_header, jwt_data)
 
 
-def verify_jwt_in_request(optional=False, fresh=False, refresh=False, locations=None):
+def verify_jwt_in_request(
+    optional=False, fresh=False, refresh=False, locations=None, token_type="access"
+):
     """
     Verify that a valid JWT is present in the request, unless ``optional=True`` in
     which case no JWT is also considered valid.
@@ -49,13 +51,18 @@ def verify_jwt_in_request(optional=False, fresh=False, refresh=False, locations=
         Defaults to ``False``.
 
     :param refresh:
-        If ``True``, require a refresh JWT to be verified.
+        If ``True``, require a refresh JWT to be verified. If ``False``, compare
+        the JWT type to ``token_type``. Defaults to ``False``.
 
     :param locations:
         A location or list of locations to look for the JWT in this request, for
         example ``'headers'`` or ``['headers', 'cookies']``. Defaluts to ``None``
         which indicates that JWTs will be looked for in the locations defined by the
         ``JWT_TOKEN_LOCATION`` configuration option.
+
+    :param token_type:
+        If ``refresh`` is ``False``, then the ``type`` claim on the JWT must exactly match
+        this string in order to be verified. Defaults to ``"access"``.
     """
     if request.method in config.exempt_methods:
         return
@@ -67,7 +74,7 @@ def verify_jwt_in_request(optional=False, fresh=False, refresh=False, locations=
             )
         else:
             jwt_data, jwt_header, jwt_location = _decode_jwt_from_request(
-                locations, fresh
+                locations, fresh, refresh=False, token_type=token_type
             )
     except NoAuthorizationError:
         if not optional:
@@ -88,7 +95,9 @@ def verify_jwt_in_request(optional=False, fresh=False, refresh=False, locations=
     return jwt_header, jwt_data
 
 
-def jwt_required(optional=False, fresh=False, refresh=False, locations=None):
+def jwt_required(
+    optional=False, fresh=False, refresh=False, locations=None, token_type="access"
+):
     """
     A decorator to protect a Flask endpoint with JSON Web Tokens.
 
@@ -106,19 +115,24 @@ def jwt_required(optional=False, fresh=False, refresh=False, locations=None):
 
     :param refresh:
         If ``True``, requires a refresh JWT to access this endpoint. If ``False``,
-        requires an access JWT to access this endpoint. Defaults to ``False``.
+        requires a JWT specified by ``token_type`` to access
+        this endpoint. Defaults to ``False``.
 
     :param locations:
         A location or list of locations to look for the JWT in this request, for
         example ``'headers'`` or ``['headers', 'cookies']``. Defaluts to ``None``
         which indicates that JWTs will be looked for in the locations defined by the
         ``JWT_TOKEN_LOCATION`` configuration option.
+
+    :param token_type:
+        If ``refresh`` is ``False``, then the ``type`` claim on the JWT must exactly match
+        this string to access this endpoint. Defaults to ``"access"``.
     """
 
     def wrapper(fn):
         @wraps(fn)
         def decorator(*args, **kwargs):
-            verify_jwt_in_request(optional, fresh, refresh, locations)
+            verify_jwt_in_request(optional, fresh, refresh, locations, token_type)
 
             # Compatibility with flask < 2.0
             try:
@@ -253,7 +267,7 @@ def _decode_jwt_from_json(refresh):
     return encoded_token, None
 
 
-def _decode_jwt_from_request(locations, fresh, refresh=False):
+def _decode_jwt_from_request(locations, fresh, refresh=False, token_type="access"):
     # Figure out what locations to look for the JWT in this request
     if isinstance(locations, str):
         locations = [locations]
@@ -312,7 +326,7 @@ def _decode_jwt_from_request(locations, fresh, refresh=False):
             raise NoAuthorizationError(errors[0])
 
     # Additional verifications provided by this extension
-    verify_token_type(decoded_token, refresh)
+    verify_token_type(decoded_token, refresh, token_type)
     if fresh:
         _verify_token_is_fresh(jwt_header, decoded_token)
     verify_token_not_blocklisted(jwt_header, decoded_token)


### PR DESCRIPTION
Added the ability to create tokens with types other than "access" and "refresh", among some other intuitive changes. This is done in such a way that will not introduce any breaking changes. This is useful in such scenarios such as password reset emails, where a JWT needs to be provided to authenticate the user, but an access token and refresh token don't fulfill that purpose.

_Summary of changes_
- Added `create_custom_token` with an additional parameter `token_type`
- Modified `verify_jwt_in_request`/`jwt_required` to allow for the additional specification of a `token_type`
- Modified `verify_token_type` to check for custom token types, and modified the resulting error messages accordingly.
    - A few tests were modified in order to satisfy these changed error messages.
- Added tests for custom types.
- Swapped the default for non-refresh token expiry time when encoding tokens. This was done to match the way defaults are handled when decoding tokens. Custom tokens will default to access token expiry time if an `expires_delta` is not provided, instead of the refresh token expiry time as before.