### PR TITLE
Support python 3.12 and add support for flask 3.0

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy3.9']
+        python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', 'pypy3.9']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,9 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install Dependencies
         run: pip install tox
-      - name: Run Tox
+      - name: Run Tox Flask==3.x
         run: tox -e py
       - name: Run Tox Flask==2.1
         run: tox -e flask21
+      - name: Run Tox Flask==2.x
+        run: tox -e flask2x

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ tox
 A subset of checks can also be ran by adding an argument to tox. The available
 arguments are:
 
--   py37, py38, py39, py310, pypy3
+-   py37, py38, py39, py310, py311, py312, pypy3
     -   Run unit tests on the given python version
 -   mypy
     -   Run mypy type checking

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black==21.12b0
 cryptography==41.0.4
-Flask==2.3.2
+Flask==3.0.0
 pre-commit==2.18.1
 PyJWT==2.7.0
 tox==3.25.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     platforms="any",
     install_requires=[
         "Werkzeug>=0.14",  # Needed for SameSite cookie functionality
-        "Flask>=2.0,<3.0",
+        "Flask>=2.0,<4.0",
         "PyJWT>=2.0,<3.0",
         "typing_extensions>=3.7.4; python_version<'3.8'",  # typing.Literal
     ],
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy3.9,flask21,mypy,coverage,style,docs
+envlist = py37,py38,py39,py310,py311,py312,pypy3.9,flask21,mypy,coverage,style,docs
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
   cryptography
   python-dateutil
   flask21: Flask>=2.1,<2.2
+  flask21: Werkzeug>=2,<3
 
 [testenv:mypy]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39,py310,py311,py312,pypy3.9,flask21,mypy,coverage,style,docs
+envlist = py37,py38,py39,py310,py311,py312,pypy3.9,flask21,flask2x,mypy,coverage,style,docs
 
 [testenv]
 commands =
@@ -15,6 +15,8 @@ deps =
   python-dateutil
   flask21: Flask>=2.1,<2.2
   flask21: Werkzeug>=2,<3
+  flask2x: Flask<3.0
+  flask2x: Werkzeug>=2,<3
 
 [testenv:mypy]
 commands =


### PR DESCRIPTION
Had to make some tweaks to the tox.ini to lock the werkzeug version, as installing a clean install of flask 2.x installs a non-compatible version 😢 

https://github.com/pallets/flask/issues/5279