### PR TITLE
typos fixed blocklist -> blacklist

### DIFF
--- a/docs/blocklist_and_token_revoking.rst
+++ b/docs/blocklist_and_token_revoking.rst
@@ -5,9 +5,9 @@ JWT Revoking / Blocklist
 JWT revoking is a mechanism for preventing an otherwise valid JWT from accessing your
 routes while still letting other valid JWTs in. To utilize JWT revoking in this
 extension, you must define a callback function via the
-:meth:`~flask_jwt_extended.JWTManager.token_in_blocklist_loader` decorator.
+:meth:`~flask_jwt_extended.JWTManager.token_in_blacklist_loader` decorator.
 This function is called whenever a valid JWT is used to access a protected route.
-The callback will receive the JWT header and JWT payload as arguments, and must
+The callback will receive the JWT header and JWT payload as arguments and must
 return ``True`` if the JWT has been revoked.
 
 In production, you will want to use some form of persistent storage (database,
@@ -18,7 +18,7 @@ your specific application and tech stack.
 
 Redis
 ~~~~~
-If your only requirements are to check if a JWT has been revoked, our recommendation
+If your only requirement is to check if a JWT has been revoked, our recommendation
 is to use redis. It is blazing fast, can be configured to persist data to disc,
 and can automatically clear out JWTs after they expire by utilizing the Time To
 Live (TTL) functionality when storing a JWT. Here is an example using redis:
@@ -27,10 +27,10 @@ Live (TTL) functionality when storing a JWT. Here is an example using redis:
 
 
 .. warning::
-    Note that configuring redis to be disk-persistent is an absolutely necessity for
+    Note that configuring redis to be disk-persistent is an absolute necessity for
     production use. Otherwise, events like power outages or server crashes/reboots
     would cause all invalidated tokens to become valid again (assuming the
-    secret key does not change). This is especially concering for long-lived
+    secret key does not change). This is especially concerning for long-lived
     refresh tokens, discussed below.
 
 Database
@@ -111,12 +111,12 @@ Alternatively, there are a few ways to revoke both tokens at once:
    with the access token. Upon revoking the access token, extract the refresh jti from it
    and invalidate both. This has the advantage of requiring no extra work from the frontend.
 #. Store every generated tokens jti in a database upon creation. Have a boolean column to represent
-   whether it is valid or not, which the ``token_in_blocklist_loader`` should respond based upon.
+   whether it is valid or not, which the ``token_in_blacklist_loader`` should respond based upon.
    Upon revoking a token, mark that token row as invalid, as well as all other tokens from the same
    user generated at the same time. This would also allow for a "log out everywhere" option where
-   all tokens for a user are invalidated at once, which is otherwise not easily possibile
+   all tokens for a user are invalidated at once, which is otherwise not easily possible
 
 
 The best option of course depends and needs to be chosen based upon the circumstances. If there
-if ever a time where an unknown, untracked token needs to be immediately invalidated, this can
+if ever a time when an unknown, untracked token needs to be immediately invalidated, this can
 be accomplished by changing the secret key.

--- a/examples/blocklist_database.py
+++ b/examples/blocklist_database.py
@@ -40,7 +40,7 @@ class TokenBlocklist(db.Model):
 
 
 # Callback function to check if a JWT exists in the database blocklist
-@jwt.token_in_blocklist_loader
+@jwt.token_in_blacklist_loader
 def check_if_token_revoked(jwt_header, jwt_payload: dict) -> bool:
     jti = jwt_payload["jti"]
     token = db.session.query(TokenBlocklist.id).filter_by(jti=jti).scalar()

--- a/examples/blocklist_redis.py
+++ b/examples/blocklist_redis.py
@@ -25,7 +25,7 @@ jwt_redis_blocklist = redis.StrictRedis(
 
 
 # Callback function to check if a JWT exists in the redis blocklist
-@jwt.token_in_blocklist_loader
+@jwt.token_in_blacklist_loader
 def check_if_token_is_revoked(jwt_header, jwt_payload: dict):
     jti = jwt_payload["jti"]
     token_in_redis = jwt_redis_blocklist.get(jti)


### PR DESCRIPTION
I found a problem here: https://github.com/gustawdaniel/flask-jwt-extended/blob/patch-1/docs/blocklist_and_token_revoking.rst

this is source code

```
    def token_in_blacklist_loader(self, callback):
        """
        This decorator sets the callback function that will be called when
        a protected endpoint is accessed and will check if the JWT has been
        been revoked. By default, this callback is not used.

        *HINT*: The callback must be a function that takes **one** argument, which is the
        decoded JWT (python dictionary), and returns *`True`* if the token
        has been blacklisted (or is otherwise considered revoked), or *`False`*
        otherwise.
        """
        self._token_in_blacklist_callback = callback
        return callback
```

with blacklist, no blocklist. Version:

```
flask-jwt-extended~=3.25.1
```       