### PR TITLE
Drop support for python 3.7 and 3.8, add 3.13

### DIFF
--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10']
+        python: [3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', 'pypy3.9']
+        python: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy3.9']
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]

--- a/flask_jwt_extended/typing.py
+++ b/flask_jwt_extended/typing.py
@@ -1,11 +1,6 @@
-import sys
 from datetime import timedelta
+from typing import Literal
 from typing import Union
-
-if sys.version_info >= (3, 8):
-    from typing import Literal  # pragma: no cover
-else:
-    from typing_extensions import Literal  # pragma: no cover
 
 ExpiresDelta = Union[Literal[False], timedelta]
 Fresh = Union[bool, float, timedelta]

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,9 @@ setup(
         "Werkzeug>=0.14",  # Needed for SameSite cookie functionality
         "Flask>=2.0,<4.0",
         "PyJWT>=2.0,<3.0",
-        "typing_extensions>=3.7.4; python_version<'3.8'",  # typing.Literal
     ],
     extras_require={"asymmetric_crypto": ["cryptography>=3.3.1"]},
-    python_requires=">=3.7,<4",
+    python_requires=">=3.9,<4",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39,py310,py311,py312,pypy3.9,flask21,flask2x,mypy,coverage,style,docs
+envlist = py39,py310,py311,py312,py313,pypy3.9,flask21,flask2x,mypy,coverage,style,docs
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.7 and 3.8 have reached their end of life, and support
for them has been dropped by upstream libraries we rely on.
