### PR TITLE
Remove python 3.8 workaround in tests.

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
+import importlib.metadata
 import json
-import sys
 from datetime import date
 from datetime import timedelta
 
@@ -12,20 +12,7 @@ from flask_jwt_extended.config import config
 from flask_jwt_extended.internal_utils import JSONEncoder
 
 
-def get_package_version(package_name):
-    if sys.version_info >= (3, 8):
-        # Use importlib.metadata for Python 3.8 and newer
-        import importlib.metadata
-
-        return importlib.metadata.version(package_name)
-    else:
-        # Use pkg_resources for older versions
-        import pkg_resources
-
-        return pkg_resources.get_distribution(package_name).version
-
-
-flask_version = get_package_version("flask")
+flask_version = importlib.metadata.version("flask")
 flask_version_tuple = tuple(map(int, flask_version.split(".")))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ deps =
   python-dateutil
   types-python-dateutil
   mypy
-  types-setuptools
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
Support for python was dropped in #559
