### PR TITLE
Add controls for `verify_sub` option in PyJWT

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -29,6 +29,7 @@ Overview:
   * `JWT_REFRESH_TOKEN_EXPIRES`_
   * `JWT_SECRET_KEY`_
   * `JWT_TOKEN_LOCATION`_
+  * `JWT_VERIFY_SUB`_
 
 - `Header Options:`_
 
@@ -254,6 +255,18 @@ General Options:
     argument in :func:`flask_jwt_extended.jwt_required`.
 
     Default: ``"headers"``
+
+.. _JWT_VERIFY_SUB:
+.. py:data:: JWT_VERIFY_SUB
+
+    Control whether the ``sub`` claim is verified during JWT decoding.
+
+    The ``sub`` claim MUST be a ``str`` according the the JWT spec. Setting this option
+    to ``True`` (the default) will enforce this requirement, and consider non-compliant
+    JWTs invalid. Setting the option to ``False`` will skip this validation of the type
+    of the ``sub`` claim, allowing any type for the ``sub`` claim to be considered valid.
+
+    Default: ``True``
 
 
 Header Options:

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -308,6 +308,10 @@ class _Config(object):
         return current_app.config["JWT_DECODE_LEEWAY"]
 
     @property
+    def verify_sub(self) -> bool:
+        return current_app.config["JWT_VERIFY_SUB"]
+
+    @property
     def encode_nbf(self) -> bool:
         return current_app.config["JWT_ENCODE_NBF"]
 

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -228,6 +228,7 @@ class JWTManager(object):
         app.config.setdefault("JWT_SECRET_KEY", None)
         app.config.setdefault("JWT_SESSION_COOKIE", True)
         app.config.setdefault("JWT_TOKEN_LOCATION", ("headers",))
+        app.config.setdefault("JWT_VERIFY_SUB", True)
         app.config.setdefault("JWT_ENCODE_NBF", True)
 
     def additional_claims_loader(self, callback: Callable) -> Callable:
@@ -549,6 +550,7 @@ class JWTManager(object):
             "leeway": config.leeway,
             "secret": secret,
             "verify_aud": config.decode_audience is not None,
+            "verify_sub": config.verify_sub,
         }
 
         try:

--- a/flask_jwt_extended/tokens.py
+++ b/flask_jwt_extended/tokens.py
@@ -85,8 +85,9 @@ def _decode_jwt(
     leeway: int,
     secret: str,
     verify_aud: bool,
+    verify_sub: bool,
 ) -> dict:
-    options = {"verify_aud": verify_aud}
+    options = {"verify_aud": verify_aud, "verify_sub": verify_sub}
     if allow_expired:
         options["verify_exp"] = False
 


### PR DESCRIPTION
This PR addresses the discussion in this issue: https://github.com/vimalloc/flask-jwt-extended/issues/561

For people who have historically been using values for the `sub` claim other than strings, they may need or want the ability to control PyJWT's new behavior (as of 2.10.0) which is to reject those tokens as invalid.

This work adds a new option `JWT_VERIFY_SUB` which can be used to control the `verify_sub` option when calling `jwt.decode(...)` from the PyJWT library.

The default value for `JWT_VERIFY_SUB` is `True`, which results in the `sub` claim being verified. This default results in no change to how the library behaved prior to this addition. By choosing to set `JWT_VERIFY_SUB` to `False`, the user can turn off the `verify_sub` option in the `jwt.decode` call.

I welcome feedback on the naming or anything else regarding the implementation. Also, please let me know if I missed any places where this needs to be tested or documented. Thanks!