### PR TITLE
fix: a unexpected token

### DIFF
--- a/flask_jwt_extended/view_decorators.py
+++ b/flask_jwt_extended/view_decorators.py
@@ -202,7 +202,7 @@ def _decode_jwt_from_headers() -> Tuple[str, None]:
     # <HeaderName>: <field> <value>, <field> <value>, etc...
     if header_type:
         field_values = split(r",\s*", auth_header)
-        jwt_headers = [s for s in field_values if s.split()[0] == header_type]
+        jwt_headers = [s for s in field_values if s and s.split()[0] == header_type]
         if len(jwt_headers) != 1:
             msg = (
                 f"Missing '{header_type}' type in '{header_name}' header. "

--- a/tests/test_view_decorators.py
+++ b/tests/test_view_decorators.py
@@ -253,6 +253,13 @@ def test_jwt_optional_with_no_valid_jwt(app):
     assert response.status_code == 422
     assert response.get_json() == {"msg": "Not enough segments"}
 
+    # Unexpected token
+    response = test_client.get(url, headers={"Authorization": "Bearer ,,0"})
+    assert response.status_code == 422
+    assert response.get_json() == {
+        "msg": "Bad Authorization header. Expected 'Authorization: Bearer <JWT>'"
+    }
+
 
 def test_override_jwt_location(app):
     app.config["JWT_TOKEN_LOCATION"] = ["cookies"]


### PR DESCRIPTION
I found a bug while using the automated testing tool.

```sh
curl -X GET -H 'Authorization: Bearer ,,0' http://localhost:5000/myapi
```
This request caused an exception.

```
ERROR    app:app.py:875 Exception on /myapi [GET]
Traceback (most recent call last):
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask_jwt_extended/view_decorators.py", line 167, in decorator
    verify_jwt_in_request(
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask_jwt_extended/view_decorators.py", line 94, in verify_jwt_in_request
    jwt_data, jwt_header, jwt_location = _decode_jwt_from_request(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask_jwt_extended/view_decorators.py", line 340, in _decode_jwt_from_request
    encoded_token, csrf_token = get_encoded_token_function()
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lee/workspace/oneproject-logo/.venv/lib/python3.12/site-packages/flask_jwt_extended/view_decorators.py", line 206, in _decode_jwt_from_headers
    jwt_headers = [s for s in field_values if s.split()[0] == header_type]
                                              ~~~~~~~~~^^^
IndexError: list index out of range
```
