### PR TITLE
Add support for partitioned (CHIPS) cookies

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -44,6 +44,7 @@ Overview:
   * `JWT_COOKIE_DOMAIN`_
   * `JWT_COOKIE_SAMESITE`_
   * `JWT_COOKIE_SECURE`_
+  * `JWT_COOKIE_PARTITIONED`_
   * `JWT_REFRESH_COOKIE_NAME`_
   * `JWT_REFRESH_COOKIE_PATH`_
   * `JWT_SESSION_COOKIE`_
@@ -358,6 +359,18 @@ These are only applicable if a route is configured to accept JWTs via cookies.
 
     Default: ``False``
 
+.. _JWT_COOKIE_PARTITIONED:
+.. py:data:: JWT_COOKIE_PARTITIONED
+
+    Controls if the ``partitioned`` flag should be placed on cookies
+    created by this extension.
+
+    Cookies Having Independent Partitioned State (CHIPS, also known as
+    Partitioned cookies) allows developers to opt a cookie into
+    partitioned storage, with a separate cookie jar per top-level
+    site.
+
+    Default: ``False``
 
 .. _JWT_REFRESH_COOKIE_NAME:
 .. py:data:: JWT_REFRESH_COOKIE_NAME

--- a/flask_jwt_extended/config.py
+++ b/flask_jwt_extended/config.py
@@ -119,6 +119,10 @@ class _Config(object):
         return current_app.config["JWT_COOKIE_DOMAIN"]
 
     @property
+    def cookie_partitioned(self) -> bool:
+        return current_app.config["JWT_COOKIE_PARTITIONED"]
+
+    @property
     def session_cookie(self) -> bool:
         return current_app.config["JWT_SESSION_COOKIE"]
 

--- a/flask_jwt_extended/jwt_manager.py
+++ b/flask_jwt_extended/jwt_manager.py
@@ -199,6 +199,7 @@ class JWTManager(object):
         app.config.setdefault("JWT_COOKIE_DOMAIN", None)
         app.config.setdefault("JWT_COOKIE_SAMESITE", None)
         app.config.setdefault("JWT_COOKIE_SECURE", False)
+        app.config.setdefault("JWT_COOKIE_PARTITIONED", False)
         app.config.setdefault("JWT_CSRF_CHECK_FORM", False)
         app.config.setdefault("JWT_CSRF_IN_COOKIES", True)
         app.config.setdefault("JWT_CSRF_METHODS", ["POST", "PUT", "PATCH", "DELETE"])

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -301,6 +301,7 @@ def set_access_cookies(
         domain=domain or config.cookie_domain,
         path=config.access_cookie_path,
         samesite=config.cookie_samesite,
+        partitioned=config.cookie_partitioned
     )
 
     if config.cookie_csrf_protect and config.csrf_in_cookies:
@@ -313,6 +314,7 @@ def set_access_cookies(
             domain=domain or config.cookie_domain,
             path=config.access_csrf_cookie_path,
             samesite=config.cookie_samesite,
+            partitioned=config.cookie_partitioned
         )
 
 

--- a/flask_jwt_extended/utils.py
+++ b/flask_jwt_extended/utils.py
@@ -356,6 +356,7 @@ def set_refresh_cookies(
         domain=domain or config.cookie_domain,
         path=config.refresh_cookie_path,
         samesite=config.cookie_samesite,
+        partitioned=config.cookie_partitioned
     )
 
     if config.cookie_csrf_protect and config.csrf_in_cookies:
@@ -368,6 +369,7 @@ def set_refresh_cookies(
             domain=domain or config.cookie_domain,
             path=config.refresh_csrf_cookie_path,
             samesite=config.cookie_samesite,
+            partitioned=config.cookie_partitioned
         )
 
 
@@ -406,6 +408,7 @@ def unset_access_cookies(response: Response, domain: Optional[str] = None) -> No
         domain=domain or config.cookie_domain,
         path=config.access_cookie_path,
         samesite=config.cookie_samesite,
+        partitioned=config.cookie_partitioned
     )
 
     if config.cookie_csrf_protect and config.csrf_in_cookies:
@@ -418,6 +421,7 @@ def unset_access_cookies(response: Response, domain: Optional[str] = None) -> No
             domain=domain or config.cookie_domain,
             path=config.access_csrf_cookie_path,
             samesite=config.cookie_samesite,
+            partitioned=config.cookie_partitioned
         )
 
 
@@ -444,6 +448,7 @@ def unset_refresh_cookies(response: Response, domain: Optional[str] = None) -> N
         domain=domain or config.cookie_domain,
         path=config.refresh_cookie_path,
         samesite=config.cookie_samesite,
+        partitioned=config.cookie_partitioned
     )
 
     if config.cookie_csrf_protect and config.csrf_in_cookies:
@@ -456,6 +461,7 @@ def unset_refresh_cookies(response: Response, domain: Optional[str] = None) -> N
             domain=domain or config.cookie_domain,
             path=config.refresh_csrf_cookie_path,
             samesite=config.cookie_samesite,
+            partitioned=config.cookie_partitioned
         )
 
 


### PR DESCRIPTION
This PR introduces support for the Partitioned attribute in cookies generated by `flask-jwt-extended`.

As browsers move toward deprecating third-party cookies, the CHIPS standard allows cookies to be set in "partitioned" storage using a new jar per top-level site. This is specifically required when the authentication server (API) resides on a different domain than the client application. Partitioned cookies prevent cross-site tracking while allowing functional cross-site needs like authentication.

## The Problem

Without the Partitioned attribute, browsers are beginning to surface the following warning (and will eventually block the cookie entirely), when the authentication server resides on a different domain than the client application:

> Cookie ‘access_token_cookie’ will soon be rejected because it is foreign and does not have the ‘Partitioned’ attribute.

## Changes

* Added `JWT_COOKIE_PARTITIONED` configuration variable (defaults to `False`).

* Updated `set_access_cookies` and `set_refresh_cookies` to include the partitioned parameter when calling `set_cookie`.