### PR TITLE
setup.py: bump PyJWT floor to >=2.11.0 to match the actual runtime requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ setup(
     install_requires=[
         "Werkzeug>=0.14",  # Needed for SameSite cookie functionality
         "Flask>=2.0,<4.0",
-        "PyJWT>=2.0,<3.0",
+        # `flask_jwt_extended/tokens.py` imports `Options` from `jwt.types`,
+        # which was first added in PyJWT 2.11.0. Earlier 2.x releases parse
+        # the import-time `from jwt.types import Options` as an ImportError.
+        "PyJWT>=2.11.0,<3.0",
     ],
     extras_require={"asymmetric_crypto": ["cryptography>=3.3.1"]},
     python_requires=">=3.10,<4",


### PR DESCRIPTION
Hi! `flask_jwt_extended/tokens.py` does:

```python
from jwt.types import Options
```

…and `jwt.types.Options` was first added in **PyJWT 2.11.0** (released 2026-01-30). The current `install_requires` in `setup.py` declares `PyJWT>=2.0,<3.0`, which is wide enough for resolvers to land on PyJWT 2.10.x and earlier — those installs then fail at `import flask_jwt_extended` time with:

```
ImportError: cannot import name 'Options' from 'jwt.types'
```

PR #574 (commit 9bf8d353, "Bump PyJWT to 2.12.1") already bumped the dev `requirements.txt` to PyJWT 2.12.1, but the package's own `install_requires` floor was left at `>=2.0`. This bridges that gap so downstream consumers (e.g. flask-appbuilder, apache-airflow) can rely on `pip install flask-jwt-extended` resulting in a working import without having to add their own defensive PyJWT pin.

Same class of issue as #553 — a runtime import that requires a newer PyJWT than the declared floor admits.

The upper bound (`<3.0`) is unchanged.

I'm happy to add a CHANGELOG entry / open a release-note PR separately if helpful.

---
Drafted-by: Claude Opus 4.7 (1M context); reviewed by @potiuk before posting