### PR TITLE
Replace deprecated datetime.utcnow() in test_nbf_token_in_future

### DIFF
--- a/tests/test_decode_tokens.py
+++ b/tests/test_decode_tokens.py
@@ -155,7 +155,7 @@ def test_never_expire_token(app):
 
 
 def test_nbf_token_in_future(app):
-    date_in_future = datetime.utcnow() + timedelta(seconds=30)
+    date_in_future = datetime.now(timezone.utc) + timedelta(seconds=30)
 
     with pytest.raises(ImmatureSignatureError):
         with app.test_request_context():


### PR DESCRIPTION
## Summary

`test_nbf_token_in_future` builds a future `nbf` claim with `datetime.utcnow()`:

```python
date_in_future = datetime.utcnow() + timedelta(seconds=30)
```

`datetime.utcnow()` is deprecated since Python 3.12 and emits a `DeprecationWarning`. The test module already imports `timezone` (line 3) and uses timezone-aware datetimes elsewhere, so this is also an inconsistency.

## Fix

Use `datetime.now(timezone.utc)`, matching the module's existing convention.

```python
date_in_future = datetime.now(timezone.utc) + timedelta(seconds=30)
```

## Verification

- `tests/test_decode_tokens.py` — **41 passed**.
- Confirmed the old call emits `DeprecationWarning: datetime.datetime.utcnow() is deprecated ...`; no `utcnow()` remains in the file.

Test-only, one-line change.
